### PR TITLE
Update to text truncation for the Label widget

### DIFF
--- a/config/devices/chrome-20_0-default.json
+++ b/config/devices/chrome-20_0-default.json
@@ -106,5 +106,8 @@
   ],
   "networking": {
     "supportsJSONP": true
+  },
+  "css": {
+    "supportsTextTruncation": true
   }
 }

--- a/static/script-tests/tests/devices/browserdevice.js
+++ b/static/script-tests/tests/devices/browserdevice.js
@@ -721,19 +721,6 @@
 			assertEquals("innerID", clone.childNodes[0].id);
 		});
 	};
-	this.BrowserDeviceTest.prototype.testGetTextHeight = function(queue) {
-		expectAsserts(3);
-
-		queuedRequire(queue, ["antie/devices/browserdevice"], function(BrowserDevice) {
-			var device = new BrowserDevice(antie.framework.deviceConfiguration);
-			assertEquals(0, device.getTextHeight("", 100, []));
-			assertNotEquals(0, device.getTextHeight("HELLO", 100, []));
-
-			var oneLine = device.getTextHeight("HELLO HELLO HELLO HELLO HELLO HELLO HELLO HELLO HELLO HELLO HELLO", 1000, []);
-			var multipleLines = device.getTextHeight("HELLO HELLO HELLO HELLO HELLO HELLO HELLO HELLO HELLO HELLO HELLO", 50, []);
-			assert(multipleLines > oneLine);
-		});
-	};
 	this.BrowserDeviceTest.prototype.testGetChildElementsByTagName = function(queue) {
 		expectAsserts(2);
 

--- a/static/script-tests/tests/widgets/label.js
+++ b/static/script-tests/tests/widgets/label.js
@@ -32,13 +32,28 @@
 	this.LabelTest.prototype.tearDown = function() {
 		this.sandbox.restore();
 	};
+
+    function stubDeviceConfig(sandbox, device, deviceSupportsTruncation) {
+        sandbox.stub(device.prototype, "getConfig", function() {
+            return {
+                css: {
+                    supportsTextTruncation: deviceSupportsTruncation
+                }
+            };
+        });
+    }
+
+
 	this.LabelTest.prototype.testInterface = function(queue) {
 		expectAsserts(2);
 
 		queuedApplicationInit(
 			queue,
 			"lib/mockapplication",
-			["antie/widgets/label","antie/widgets/widget"],
+            [
+                "antie/widgets/label",
+                "antie/widgets/widget"
+            ],
 			function(application, Label, Widget) {
 				assertEquals('Label should be a function', 'function', typeof Label);
 				assert('Label should extend from Widget', new Label() instanceof Widget);
@@ -50,7 +65,7 @@
 		queuedApplicationInit(
 				queue,
 				"lib/mockapplication",
-				["antie/widgets/label"],
+               ["antie/widgets/label"],
 				function(application, Label) {
 					var widget = new Label("hello", "world");
 
@@ -71,8 +86,10 @@
 		queuedApplicationInit(
 				queue,
 				"lib/mockapplication",
-				["antie/widgets/label"],
+                ["antie/widgets/label"],
 				function(application, Label) {
+                    stubDeviceConfig(this.sandbox, Label, null, false);
+
 					var widget1 = new Label("hello");
 					assertEquals("hello", widget1.getText());
 
@@ -93,13 +110,13 @@
 				"lib/mockapplication",
 				["antie/widgets/label"],
 				function(application, Label) {
-
                     var device = application.getDevice();
+                    stubDeviceConfig(this.sandbox, device, false);
 
                     var clock = this.sandbox.useFakeTimers();
 
                     var label = new Label("hello");
-                    var truncateTextSpy = this.sandbox.spy(label, '_truncateText');
+                    var truncateTextSpy = this.sandbox.stub(label, '_truncateText');
                     label.setTruncationMode(Label.TRUNCATION_MODE_RIGHT_ELLIPSIS);
                     label.render(device);
                     assert(!truncateTextSpy.called)
@@ -117,13 +134,13 @@
             "lib/mockapplication",
             ["antie/widgets/label"],
             function(application, Label) {
-
                 var device = application.getDevice();
+                stubDeviceConfig(this.sandbox, device, false);
 
                 var clock = this.sandbox.useFakeTimers();
 
                 var label = new Label("hello");
-                var truncateTextSpy = this.sandbox.spy(label, '_truncateText');
+                var truncateTextSpy = this.sandbox.stub(label, '_truncateText');
                 label.setTruncationMode(Label.TRUNCATION_MODE_RIGHT_ELLIPSIS);
                 label.render(device);
                 clock.tick(0);

--- a/static/script-tests/tests/widgets/label.js
+++ b/static/script-tests/tests/widgets/label.js
@@ -118,7 +118,7 @@
                     var truncateTextSpy = this.sandbox.stub(label, '_truncateText');
                     label.setTruncationMode(Label.TRUNCATION_MODE_RIGHT_ELLIPSIS);
                     label.render(device);
-                    assert(!truncateTextSpy.called)
+                    assert(!truncateTextSpy.called);
                     clock.tick(0);
                     assert(truncateTextSpy.called);
 				}
@@ -157,7 +157,7 @@
     };
 
     this.LabelTest.prototype.testSetCssForTruncationIsCalledWhenUsingCss = function(queue) {
-        expectAsserts(2);
+        expectAsserts(1);
 
         queuedApplicationInit(
             queue,
@@ -173,14 +173,13 @@
                 label.useCssForTruncationIfAvailable(true);
                 label.setMaximumLines(2);
                 label.render(device);
-                assert(!setCssForTruncationSpy.threw());
                 assert(setCssForTruncationSpy.called);
             }
         );
     };
 
     this.LabelTest.prototype.testSetTruncationAlgorithmIsUsedWhenRequestingCssButDeviceDoesNotSupportIt = function(queue) {
-        expectAsserts(2);
+        expectAsserts(1);
 
         queuedApplicationInit(
             queue,
@@ -198,7 +197,6 @@
                 label.useCssForTruncationIfAvailable(true);
                 label.setMaximumLines(2);
                 label.render(device);
-                assert(!truncateTextSpy.called);
                 clock.tick(0);
                 assert(truncateTextSpy.called);
             }
@@ -217,17 +215,12 @@
                 stubDeviceConfig(this.sandbox, device, true);
 
                 var label = new Label("hello");
-                this.sandbox.stub(label, '_setCssForTruncation');
-                var shouldUseCssForTruncationSpy = this.sandbox.spy(label, '_shouldUseCssForTruncation');
                 label.setTruncationMode(Label.TRUNCATION_MODE_RIGHT_ELLIPSIS);
                 label.useCssForTruncationIfAvailable(true);
-                try {
+
+                assertException(function() {
                     label.render(device);
-                }
-                catch(e) {
-                    // intentional
-                }
-                assert(shouldUseCssForTruncationSpy.threw("Error"));
+                }, "Error");
             }
         );
     };

--- a/static/script-tests/tests/widgets/label.js
+++ b/static/script-tests/tests/widgets/label.js
@@ -92,27 +92,46 @@
 				"lib/mockapplication",
 				["antie/widgets/label"],
 				function(application, Label) {
-					var text = "The Quick Brown Fox Jumped Over The Lazy Dog";
-					var widget1 = new Label(text);
-					application.getRootWidget().appendChildWidget(widget1);
-					assertEquals(text, widget1.getText());
+                    var text = "The Quick Brown Fox Jumped Over The Lazy Dog";
+                    var widget1 = new Label(text);
+                    application.getRootWidget().appendChildWidget(widget1);
+                    assertEquals(text, widget1.getText());
 
-					var device = application.getDevice();
-					document.body.appendChild(application.getRootWidget().render(device));
-					var el = widget1.render(device);
-					el.style.display = "block";
-					var size = device.getElementSize(el);
+                    var device = application.getDevice();
+                    document.body.appendChild(application.getRootWidget().render(device));
+                    var el = widget1.render(device);
+                    el.style.display = "block";
+                    var size = device.getElementSize(el);
 
-					widget1.setTruncationMode(Label.TRUNCATION_MODE_NONE);
-					widget1.setText(text);
-					assertEquals(size, device.getElementSize(el));
+                    widget1.setTruncationMode(Label.TRUNCATION_MODE_NONE);
+                    widget1.setText(text);
+                    assertEquals(size, device.getElementSize(el));
 
-					widget1.setMaximumLines(1);
-					widget1.setText(text);
-					assertEquals(size, device.getElementSize(el));
+                    widget1.setMaximumLines(1);
+                    widget1.setText(text);
+                    assertEquals(size, device.getElementSize(el));
 
-					widget1.setText(text);
-					assertEquals(size, device.getElementSize(el));
+                    widget1.setWidth(100);
+                    widget1.setText(text);
+                    assertEquals(size, device.getElementSize(el));
+
+                    el.style.width = "100px";
+                    widget1.setText(text);
+                    assertNotEquals(size, device.getElementSize(el));
+
+                    widget1.setTruncationMode(Label.TRUNCATION_MODE_RIGHT_ELLIPSIS);
+                    widget1.setText(text);
+
+                    var newSize = device.getElementSize(el);
+                    assert(newSize.width <= 100);
+                    assertEquals(size.height, newSize.height);
+
+                    widget1.setMaximumLines(2);
+                    widget1.setText(text);
+
+                    var newSize2 = device.getElementSize(el);
+                    assert(newSize.width <= 100);
+                    assertNotEquals(newSize.height, newSize2.height);
 				}
 		);
 	};

--- a/static/script-tests/tests/widgets/label.js
+++ b/static/script-tests/tests/widgets/label.js
@@ -98,40 +98,8 @@
                     assertEquals(text, widget1.getText());
 
                     var device = application.getDevice();
-                    document.body.appendChild(application.getRootWidget().render(device));
-                    var el = widget1.render(device);
-                    el.style.display = "block";
-                    var size = device.getElementSize(el);
 
-                    widget1.setTruncationMode(Label.TRUNCATION_MODE_NONE);
-                    widget1.setText(text);
-                    assertEquals(size, device.getElementSize(el));
-
-                    widget1.setMaximumLines(1);
-                    widget1.setText(text);
-                    assertEquals(size, device.getElementSize(el));
-
-                    widget1.setWidth(100);
-                    widget1.setText(text);
-                    assertEquals(size, device.getElementSize(el));
-
-                    el.style.width = "100px";
-                    widget1.setText(text);
-                    assertNotEquals(size, device.getElementSize(el));
-
-                    widget1.setTruncationMode(Label.TRUNCATION_MODE_RIGHT_ELLIPSIS);
-                    widget1.setText(text);
-
-                    var newSize = device.getElementSize(el);
-                    assert(newSize.width <= 100);
-                    assertEquals(size.height, newSize.height);
-
-                    widget1.setMaximumLines(2);
-                    widget1.setText(text);
-
-                    var newSize2 = device.getElementSize(el);
-                    assert(newSize.width <= 100);
-                    assertNotEquals(newSize.height, newSize2.height);
+                    // TODO
 				}
 		);
 	};

--- a/static/script-tests/tests/widgets/label.js
+++ b/static/script-tests/tests/widgets/label.js
@@ -85,51 +85,51 @@
 		);
 	};
 
-// 	this.LabelTest.prototype.testTruncateTextCalledAfterTimeoutOfZeroWhenTruncationIsEnabledOnFirstRender = function(queue) {
-//		expectAsserts(2);
-//
-//		queuedApplicationInit(
-//				queue,
-//				"lib/mockapplication",
-//				["antie/widgets/label"],
-//				function(application, Label) {
-//
-//                    var device = application.getDevice();
-//
-//                    var clock = this.sandbox.useFakeTimers();
-//
-//                    var label = new Label("hello");
-//                    var truncateTextSpy = this.sandbox.spy(label, '_truncateText');
-//                    label.setTruncationMode(Label.TRUNCATION_MODE_RIGHT_ELLIPSIS);
-//                    label.render(device);
-//                    assert(!truncateTextSpy.called)
-//                    clock.tick(0);
-//                    assert(truncateTextSpy.called);
-//				}
-//		);
-//	};
+	this.LabelTest.prototype.testTruncateTextCalledAfterTimeoutOfZeroWhenTruncationIsEnabledOnFirstRender = function(queue) {
+		expectAsserts(2);
 
-//    this.LabelTest.prototype.testTruncateTextCalledImmediatelyWhenTruncationIsEnabledOnFutureRenders = function(queue) {
-//        expectAsserts(1);
-//
-//        queuedApplicationInit(
-//            queue,
-//            "lib/mockapplication",
-//            ["antie/widgets/label"],
-//            function(application, Label) {
-//
-//                var device = application.getDevice();
-//
-//                var clock = this.sandbox.useFakeTimers();
-//
-//                var label = new Label("hello");
-//                var truncateTextSpy = this.sandbox.spy(label, '_truncateText');
-//                label.setTruncationMode(Label.TRUNCATION_MODE_RIGHT_ELLIPSIS);
-//                label.render(device);
-//                clock.tick(0);
-//                label.setText("Something else");
-//                assert(truncateTextSpy.called);
-//            }
-//        );
-//    };
+		queuedApplicationInit(
+				queue,
+				"lib/mockapplication",
+				["antie/widgets/label"],
+				function(application, Label) {
+
+                    var device = application.getDevice();
+
+                    var clock = this.sandbox.useFakeTimers();
+
+                    var label = new Label("hello");
+                    var truncateTextSpy = this.sandbox.spy(label, '_truncateText');
+                    label.setTruncationMode(Label.TRUNCATION_MODE_RIGHT_ELLIPSIS);
+                    label.render(device);
+                    assert(!truncateTextSpy.called)
+                    clock.tick(0);
+                    assert(truncateTextSpy.called);
+				}
+		);
+	};
+
+    this.LabelTest.prototype.testTruncateTextCalledImmediatelyWhenTruncationIsEnabledOnFutureRenders = function(queue) {
+        expectAsserts(1);
+
+        queuedApplicationInit(
+            queue,
+            "lib/mockapplication",
+            ["antie/widgets/label"],
+            function(application, Label) {
+
+                var device = application.getDevice();
+
+                var clock = this.sandbox.useFakeTimers();
+
+                var label = new Label("hello");
+                var truncateTextSpy = this.sandbox.spy(label, '_truncateText');
+                label.setTruncationMode(Label.TRUNCATION_MODE_RIGHT_ELLIPSIS);
+                label.render(device);
+                clock.tick(0);
+                label.setText("Something else");
+                assert(truncateTextSpy.called);
+            }
+        );
+    };
 })();

--- a/static/script-tests/tests/widgets/label.js
+++ b/static/script-tests/tests/widgets/label.js
@@ -171,6 +171,7 @@
                 var label = new Label("hello");
                 var setCssForTruncationSpy = this.sandbox.stub(label, '_setCssForTruncation');
                 label.setTruncationMode(Label.TRUNCATION_MODE_RIGHT_ELLIPSIS);
+                label.setSplitAtWordBoundary(false);
                 label.useCssForTruncationIfAvailable(true);
                 label.setMaximumLines(2);
                 label.render(device);
@@ -195,6 +196,7 @@
                 var label = new Label("hello");
                 var truncateTextSpy = this.sandbox.stub(label, '_truncateText');
                 label.setTruncationMode(Label.TRUNCATION_MODE_RIGHT_ELLIPSIS);
+                label.setSplitAtWordBoundary(false);
                 label.useCssForTruncationIfAvailable(true);
                 label.setMaximumLines(2);
                 label.render(device);
@@ -218,6 +220,31 @@
                 var label = new Label("hello");
                 label.setTruncationMode(Label.TRUNCATION_MODE_RIGHT_ELLIPSIS);
                 label.useCssForTruncationIfAvailable(true);
+                label.setSplitAtWordBoundary(false);
+
+                assertException(function() {
+                    label.render(device);
+                }, "Error");
+            }
+        );
+    };
+
+    this.LabelTest.prototype.testExceptionThrownWhenTryingToUseCssWithTheTruncateAtWordBoundarySet = function(queue) {
+        expectAsserts(1);
+
+        queuedApplicationInit(
+            queue,
+            "lib/mockapplication",
+            ["antie/widgets/label"],
+            function(application, Label) {
+                var device = application.getDevice();
+                stubDeviceConfig(this.sandbox, device, true);
+
+                var label = new Label("hello");
+                label.setTruncationMode(Label.TRUNCATION_MODE_RIGHT_ELLIPSIS);
+                label.useCssForTruncationIfAvailable(true);
+                label.setSplitAtWordBoundary(true);
+                label.setMaximumLines(2);
 
                 assertException(function() {
                     label.render(device);

--- a/static/script-tests/tests/widgets/label.js
+++ b/static/script-tests/tests/widgets/label.js
@@ -84,23 +84,51 @@
 				}
 		);
 	};
- 	this.LabelTest.prototype.testTruncation = function(queue) {
-		expectAsserts(4);
+ 	this.LabelTest.prototype.testTruncateTextCalledAfterTimeoutOfZeroWhenTruncationIsEnabledOnFirstRender = function(queue) {
+		expectAsserts(2);
 
 		queuedApplicationInit(
 				queue,
 				"lib/mockapplication",
 				["antie/widgets/label"],
 				function(application, Label) {
-                    var text = "The Quick Brown Fox Jumped Over The Lazy Dog";
-                    var widget1 = new Label(text);
-                    application.getRootWidget().appendChildWidget(widget1);
-                    assertEquals(text, widget1.getText());
 
                     var device = application.getDevice();
 
-                    // TODO
+                    var clock = this.sandbox.useFakeTimers();
+
+                    var label = new Label("hello");
+                    var truncateTextSpy = this.sandbox.spy(label, '_truncateText');
+                    label.setTruncationMode(Label.TRUNCATION_MODE_RIGHT_ELLIPSIS);
+                    label.render(device);
+                    assert(!truncateTextSpy.called)
+                    clock.tick(0);
+                    assert(truncateTextSpy.called);
 				}
 		);
 	};
+
+    this.LabelTest.prototype.testTruncateTextCalledImmediatelyWhenTruncationIsEnabledOnFutureRenders = function(queue) {
+        expectAsserts(1);
+
+        queuedApplicationInit(
+            queue,
+            "lib/mockapplication",
+            ["antie/widgets/label"],
+            function(application, Label) {
+
+                var device = application.getDevice();
+
+                var clock = this.sandbox.useFakeTimers();
+
+                var label = new Label("hello");
+                var truncateTextSpy = this.sandbox.spy(label, '_truncateText');
+                label.setTruncationMode(Label.TRUNCATION_MODE_RIGHT_ELLIPSIS);
+                label.render(device);
+                clock.tick(0);
+                label.setText("Something else");
+                assert(truncateTextSpy.called);
+            }
+        );
+    };
 })();

--- a/static/script-tests/tests/widgets/label.js
+++ b/static/script-tests/tests/widgets/label.js
@@ -120,7 +120,7 @@
                     label.render(device);
                     assert(!truncateTextSpy.called);
                     clock.tick(0);
-                    assert(truncateTextSpy.called);
+                    assert(truncateTextSpy.calledOnce);
 				}
 		);
 	};
@@ -146,12 +146,13 @@
                         }
                     };
                 });
+                this.sandbox.stub(document, "contains").returns(true);
                 var truncateTextSpy = this.sandbox.stub(label, '_truncateText');
                 label.setTruncationMode(Label.TRUNCATION_MODE_RIGHT_ELLIPSIS);
                 label.render(device);
                 clock.tick(0);
                 label.setText("Something else");
-                assert(truncateTextSpy.called);
+                assert(truncateTextSpy.calledTwice);
             }
         );
     };
@@ -173,7 +174,7 @@
                 label.useCssForTruncationIfAvailable(true);
                 label.setMaximumLines(2);
                 label.render(device);
-                assert(setCssForTruncationSpy.called);
+                assert(setCssForTruncationSpy.calledOnce);
             }
         );
     };
@@ -198,7 +199,7 @@
                 label.setMaximumLines(2);
                 label.render(device);
                 clock.tick(0);
-                assert(truncateTextSpy.called);
+                assert(truncateTextSpy.calledOnce);
             }
         );
     };

--- a/static/script-tests/tests/widgets/label.js
+++ b/static/script-tests/tests/widgets/label.js
@@ -198,7 +198,7 @@
                 label.useCssForTruncationIfAvailable(true);
                 label.setMaximumLines(2);
                 label.render(device);
-                assert(!truncateTextSpy.called)
+                assert(!truncateTextSpy.called);
                 clock.tick(0);
                 assert(truncateTextSpy.called);
             }

--- a/static/script-tests/tests/widgets/label.js
+++ b/static/script-tests/tests/widgets/label.js
@@ -227,7 +227,7 @@
                 catch(e) {
                     // intentional
                 }
-                assert(shouldUseCssForTruncationSpy.threw());
+                assert(shouldUseCssForTruncationSpy.threw("Error"));
             }
         );
     };

--- a/static/script-tests/tests/widgets/label.js
+++ b/static/script-tests/tests/widgets/label.js
@@ -85,7 +85,7 @@
 		);
 	};
  	this.LabelTest.prototype.testTruncation = function(queue) {
-		expectAsserts(9);
+		expectAsserts(4);
 
 		queuedApplicationInit(
 				queue,
@@ -111,27 +111,8 @@
 					widget1.setText(text);
 					assertEquals(size, device.getElementSize(el));
 
-					widget1.setWidth(100);
 					widget1.setText(text);
 					assertEquals(size, device.getElementSize(el));
-
-					el.style.width = "100px";
-					widget1.setText(text);
-					assertNotEquals(size, device.getElementSize(el));
-
-					widget1.setTruncationMode(Label.TRUNCATION_MODE_RIGHT_ELLIPSIS);
-					widget1.setText(text);
-
-					var newSize = device.getElementSize(el);
-					assert(newSize.width <= 100);
-					assertEquals(size.height, newSize.height);
-
-					widget1.setMaximumLines(2);
-					widget1.setText(text);
-
-					var newSize2 = device.getElementSize(el);
-					assert(newSize.width <= 100);
-					assertNotEquals(newSize.height, newSize2.height);
 				}
 		);
 	};

--- a/static/script-tests/tests/widgets/label.js
+++ b/static/script-tests/tests/widgets/label.js
@@ -179,6 +179,32 @@
         );
     };
 
+    this.LabelTest.prototype.testSetTruncationAlgorithmIsUsedWhenRequestingCssButDeviceDoesNotSupportIt = function(queue) {
+        expectAsserts(2);
+
+        queuedApplicationInit(
+            queue,
+            "lib/mockapplication",
+            ["antie/widgets/label"],
+            function(application, Label) {
+                var device = application.getDevice();
+                stubDeviceConfig(this.sandbox, device, false);
+
+                var clock = this.sandbox.useFakeTimers();
+
+                var label = new Label("hello");
+                var truncateTextSpy = this.sandbox.stub(label, '_truncateText');
+                label.setTruncationMode(Label.TRUNCATION_MODE_RIGHT_ELLIPSIS);
+                label.useCssForTruncationIfAvailable(true);
+                label.setMaximumLines(2);
+                label.render(device);
+                assert(!truncateTextSpy.called)
+                clock.tick(0);
+                assert(truncateTextSpy.called);
+            }
+        );
+    };
+
     this.LabelTest.prototype.testExceptionThrownWhenTryingToUseCssWithoutSpecifyingNumberOfLines = function(queue) {
         expectAsserts(1);
 

--- a/static/script-tests/tests/widgets/label.js
+++ b/static/script-tests/tests/widgets/label.js
@@ -84,51 +84,52 @@
 				}
 		);
 	};
- 	this.LabelTest.prototype.testTruncateTextCalledAfterTimeoutOfZeroWhenTruncationIsEnabledOnFirstRender = function(queue) {
-		expectAsserts(2);
 
-		queuedApplicationInit(
-				queue,
-				"lib/mockapplication",
-				["antie/widgets/label"],
-				function(application, Label) {
+// 	this.LabelTest.prototype.testTruncateTextCalledAfterTimeoutOfZeroWhenTruncationIsEnabledOnFirstRender = function(queue) {
+//		expectAsserts(2);
+//
+//		queuedApplicationInit(
+//				queue,
+//				"lib/mockapplication",
+//				["antie/widgets/label"],
+//				function(application, Label) {
+//
+//                    var device = application.getDevice();
+//
+//                    var clock = this.sandbox.useFakeTimers();
+//
+//                    var label = new Label("hello");
+//                    var truncateTextSpy = this.sandbox.spy(label, '_truncateText');
+//                    label.setTruncationMode(Label.TRUNCATION_MODE_RIGHT_ELLIPSIS);
+//                    label.render(device);
+//                    assert(!truncateTextSpy.called)
+//                    clock.tick(0);
+//                    assert(truncateTextSpy.called);
+//				}
+//		);
+//	};
 
-                    var device = application.getDevice();
-
-                    var clock = this.sandbox.useFakeTimers();
-
-                    var label = new Label("hello");
-                    var truncateTextSpy = this.sandbox.spy(label, '_truncateText');
-                    label.setTruncationMode(Label.TRUNCATION_MODE_RIGHT_ELLIPSIS);
-                    label.render(device);
-                    assert(!truncateTextSpy.called)
-                    clock.tick(0);
-                    assert(truncateTextSpy.called);
-				}
-		);
-	};
-
-    this.LabelTest.prototype.testTruncateTextCalledImmediatelyWhenTruncationIsEnabledOnFutureRenders = function(queue) {
-        expectAsserts(1);
-
-        queuedApplicationInit(
-            queue,
-            "lib/mockapplication",
-            ["antie/widgets/label"],
-            function(application, Label) {
-
-                var device = application.getDevice();
-
-                var clock = this.sandbox.useFakeTimers();
-
-                var label = new Label("hello");
-                var truncateTextSpy = this.sandbox.spy(label, '_truncateText');
-                label.setTruncationMode(Label.TRUNCATION_MODE_RIGHT_ELLIPSIS);
-                label.render(device);
-                clock.tick(0);
-                label.setText("Something else");
-                assert(truncateTextSpy.called);
-            }
-        );
-    };
+//    this.LabelTest.prototype.testTruncateTextCalledImmediatelyWhenTruncationIsEnabledOnFutureRenders = function(queue) {
+//        expectAsserts(1);
+//
+//        queuedApplicationInit(
+//            queue,
+//            "lib/mockapplication",
+//            ["antie/widgets/label"],
+//            function(application, Label) {
+//
+//                var device = application.getDevice();
+//
+//                var clock = this.sandbox.useFakeTimers();
+//
+//                var label = new Label("hello");
+//                var truncateTextSpy = this.sandbox.spy(label, '_truncateText');
+//                label.setTruncationMode(Label.TRUNCATION_MODE_RIGHT_ELLIPSIS);
+//                label.render(device);
+//                clock.tick(0);
+//                label.setText("Something else");
+//                assert(truncateTextSpy.called);
+//            }
+//        );
+//    };
 })();

--- a/static/script-tests/tests/widgets/label/texttruncation/cssmanager-test.js
+++ b/static/script-tests/tests/widgets/label/texttruncation/cssmanager-test.js
@@ -1,3 +1,26 @@
+/**
+ * @preserve Copyright (c) 2013 British Broadcasting Corporation
+ * (http://www.bbc.co.uk) and TAL Contributors (1)
+ *
+ * (1) TAL Contributors are listed in the AUTHORS file and at
+ *     https://github.com/fmtvp/TAL/AUTHORS - please extend this file,
+ *     not this notice.
+ *
+ * @license Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * All rights reserved
+ * Please contact us for an alternative licence
+ */
 
 (function() {
     this.tests = AsyncTestCase("CSS Manager");

--- a/static/script-tests/tests/widgets/label/texttruncation/cssmanager-test.js
+++ b/static/script-tests/tests/widgets/label/texttruncation/cssmanager-test.js
@@ -1,0 +1,74 @@
+
+(function() {
+    this.tests = AsyncTestCase("CSS Manager");
+
+    this.tests.prototype.setUp = function () {
+        this.sandbox = sinon.sandbox.create();
+        this.mockEl = {
+            style: {
+                whiteSpace: "invalidWhiteSpace",
+                width: "invalidWidth",
+                height: "invalidHeight",
+                display: "invalidDisplay"
+            }
+        };
+    };
+
+    this.tests.prototype.tearDown = function () {
+        this.sandbox.restore();
+    };
+
+    this.tests.prototype.testCheckConstructorWhenMeasuringVertically = function (queue) {
+        expectAsserts(4);
+
+        queuedRequire(queue, ["antie/widgets/label/texttruncation/cssmanager"], function(CSSManager) {
+
+            new CSSManager(this.mockEl, false);
+            assertEquals("normal", this.mockEl.style.whiteSpace);
+            assertEquals("invalidWidth", this.mockEl.style.width);
+            assertEquals("auto", this.mockEl.style.height);
+            assertEquals("inline-block", this.mockEl.style.display);
+        });
+    };
+
+    this.tests.prototype.testCheckConstructorWhenMeasuringHorizontally = function (queue) {
+        expectAsserts(4);
+
+        queuedRequire(queue, ["antie/widgets/label/texttruncation/cssmanager"], function(CSSManager) {
+
+            new CSSManager(this.mockEl, true);
+            assertEquals("nowrap", this.mockEl.style.whiteSpace);
+            assertEquals("auto", this.mockEl.style.width);
+            assertEquals("auto", this.mockEl.style.height);
+            assertEquals("inline-block", this.mockEl.style.display);
+        });
+    };
+
+    this.tests.prototype.testCheckThatRestoreRestoresCorrectCSSWhenMeasuringVertically = function (queue) {
+        expectAsserts(4);
+
+        queuedRequire(queue, ["antie/widgets/label/texttruncation/cssmanager"], function(CSSManager) {
+
+            var instance = new CSSManager(this.mockEl, false);
+            instance.restore();
+            assertEquals("invalidWhiteSpace", this.mockEl.style.whiteSpace);
+            assertEquals("invalidWidth", this.mockEl.style.width);
+            assertEquals("invalidHeight", this.mockEl.style.height);
+            assertEquals("invalidDisplay", this.mockEl.style.display);
+        });
+    };
+
+    this.tests.prototype.testCheckThatRestoreRestoresCorrectCSSWhenMeasuringHorizontally = function (queue) {
+        expectAsserts(4);
+
+        queuedRequire(queue, ["antie/widgets/label/texttruncation/cssmanager"], function(CSSManager) {
+
+            var instance = new CSSManager(this.mockEl, true);
+            instance.restore();
+            assertEquals("invalidWhiteSpace", this.mockEl.style.whiteSpace);
+            assertEquals("invalidWidth", this.mockEl.style.width);
+            assertEquals("invalidHeight", this.mockEl.style.height);
+            assertEquals("invalidDisplay", this.mockEl.style.display);
+        });
+    };
+})();

--- a/static/script-tests/tests/widgets/label/texttruncation/cssmanager-test.js
+++ b/static/script-tests/tests/widgets/label/texttruncation/cssmanager-test.js
@@ -29,6 +29,7 @@
         this.sandbox = sinon.sandbox.create();
         this.mockEl = {
             style: {
+                position: "invalidPosition",
                 whiteSpace: "invalidWhiteSpace",
                 width: "invalidWidth",
                 height: "invalidHeight",
@@ -41,12 +42,13 @@
         this.sandbox.restore();
     };
 
-    this.tests.prototype.testCheckConstructorWhenMeasuringVertically = function (queue) {
-        expectAsserts(4);
+    this.tests.prototype.testCheckConfigureForAlgorithmWhenMeasuringVertically = function (queue) {
+        expectAsserts(5);
 
         queuedRequire(queue, ["antie/widgets/label/texttruncation/cssmanager"], function(CSSManager) {
 
             new CSSManager(this.mockEl, false).configureForAlgorithm();
+            assertEquals("static", this.mockEl.style.position);
             assertEquals("normal", this.mockEl.style.whiteSpace);
             assertEquals("invalidWidth", this.mockEl.style.width);
             assertEquals("auto", this.mockEl.style.height);
@@ -54,12 +56,13 @@
         });
     };
 
-    this.tests.prototype.testCheckConstructorWhenMeasuringHorizontally = function (queue) {
-        expectAsserts(4);
+    this.tests.prototype.testCheckConfigureForAlgorithmWhenMeasuringHorizontally = function (queue) {
+        expectAsserts(5);
 
         queuedRequire(queue, ["antie/widgets/label/texttruncation/cssmanager"], function(CSSManager) {
 
             new CSSManager(this.mockEl, true).configureForAlgorithm();
+            assertEquals("static", this.mockEl.style.position);
             assertEquals("nowrap", this.mockEl.style.whiteSpace);
             assertEquals("auto", this.mockEl.style.width);
             assertEquals("auto", this.mockEl.style.height);
@@ -68,13 +71,14 @@
     };
 
     this.tests.prototype.testCheckThatRestoreRestoresCorrectCSSWhenMeasuringVertically = function (queue) {
-        expectAsserts(4);
+        expectAsserts(5);
 
         queuedRequire(queue, ["antie/widgets/label/texttruncation/cssmanager"], function(CSSManager) {
 
             var instance = new CSSManager(this.mockEl, false);
             instance.configureForAlgorithm();
             instance.restore();
+            assertEquals("invalidPosition", this.mockEl.style.position);
             assertEquals("invalidWhiteSpace", this.mockEl.style.whiteSpace);
             assertEquals("invalidWidth", this.mockEl.style.width);
             assertEquals("invalidHeight", this.mockEl.style.height);
@@ -83,13 +87,14 @@
     };
 
     this.tests.prototype.testCheckThatRestoreRestoresCorrectCSSWhenMeasuringHorizontally = function (queue) {
-        expectAsserts(4);
+        expectAsserts(5);
 
         queuedRequire(queue, ["antie/widgets/label/texttruncation/cssmanager"], function(CSSManager) {
 
             var instance = new CSSManager(this.mockEl, true);
             instance.configureForAlgorithm();
             instance.restore();
+            assertEquals("invalidPosition", this.mockEl.style.position);
             assertEquals("invalidWhiteSpace", this.mockEl.style.whiteSpace);
             assertEquals("invalidWidth", this.mockEl.style.width);
             assertEquals("invalidHeight", this.mockEl.style.height);

--- a/static/script-tests/tests/widgets/label/texttruncation/cssmanager-test.js
+++ b/static/script-tests/tests/widgets/label/texttruncation/cssmanager-test.js
@@ -46,7 +46,7 @@
 
         queuedRequire(queue, ["antie/widgets/label/texttruncation/cssmanager"], function(CSSManager) {
 
-            new CSSManager(this.mockEl, false);
+            new CSSManager(this.mockEl, false).configureForAlgorithm();
             assertEquals("normal", this.mockEl.style.whiteSpace);
             assertEquals("invalidWidth", this.mockEl.style.width);
             assertEquals("auto", this.mockEl.style.height);
@@ -59,7 +59,7 @@
 
         queuedRequire(queue, ["antie/widgets/label/texttruncation/cssmanager"], function(CSSManager) {
 
-            new CSSManager(this.mockEl, true);
+            new CSSManager(this.mockEl, true).configureForAlgorithm();
             assertEquals("nowrap", this.mockEl.style.whiteSpace);
             assertEquals("auto", this.mockEl.style.width);
             assertEquals("auto", this.mockEl.style.height);
@@ -73,6 +73,7 @@
         queuedRequire(queue, ["antie/widgets/label/texttruncation/cssmanager"], function(CSSManager) {
 
             var instance = new CSSManager(this.mockEl, false);
+            instance.configureForAlgorithm();
             instance.restore();
             assertEquals("invalidWhiteSpace", this.mockEl.style.whiteSpace);
             assertEquals("invalidWidth", this.mockEl.style.width);
@@ -87,6 +88,7 @@
         queuedRequire(queue, ["antie/widgets/label/texttruncation/cssmanager"], function(CSSManager) {
 
             var instance = new CSSManager(this.mockEl, true);
+            instance.configureForAlgorithm();
             instance.restore();
             assertEquals("invalidWhiteSpace", this.mockEl.style.whiteSpace);
             assertEquals("invalidWidth", this.mockEl.style.width);

--- a/static/script-tests/tests/widgets/label/texttruncation/cssmanager-test.js
+++ b/static/script-tests/tests/widgets/label/texttruncation/cssmanager-test.js
@@ -32,7 +32,11 @@
                 position: "invalidPosition",
                 whiteSpace: "invalidWhiteSpace",
                 width: "invalidWidth",
+                minWidth: "invalidMinWidth",
+                maxWidth: "invalidMaxWidth",
                 height: "invalidHeight",
+                minHeight: "invalidMinHeight",
+                maxHeight: "invalidMaxHeight",
                 display: "invalidDisplay"
             }
         };
@@ -43,7 +47,7 @@
     };
 
     this.tests.prototype.testCheckConfigureForAlgorithmWhenMeasuringVertically = function (queue) {
-        expectAsserts(5);
+        expectAsserts(9);
 
         queuedRequire(queue, ["antie/widgets/label/texttruncation/cssmanager"], function(CSSManager) {
 
@@ -52,12 +56,16 @@
             assertEquals("normal", this.mockEl.style.whiteSpace);
             assertEquals("invalidWidth", this.mockEl.style.width);
             assertEquals("auto", this.mockEl.style.height);
+            assertEquals("invalidMaxWidth", this.mockEl.style.maxWidth);
+            assertEquals("invalidMinWidth", this.mockEl.style.minWidth);
+            assertEquals(null, this.mockEl.style.maxHeight);
+            assertEquals(null, this.mockEl.style.minHeight);
             assertEquals("inline-block", this.mockEl.style.display);
         });
     };
 
     this.tests.prototype.testCheckConfigureForAlgorithmWhenMeasuringHorizontally = function (queue) {
-        expectAsserts(5);
+        expectAsserts(9);
 
         queuedRequire(queue, ["antie/widgets/label/texttruncation/cssmanager"], function(CSSManager) {
 
@@ -66,12 +74,16 @@
             assertEquals("nowrap", this.mockEl.style.whiteSpace);
             assertEquals("auto", this.mockEl.style.width);
             assertEquals("auto", this.mockEl.style.height);
+            assertEquals(null, this.mockEl.style.maxWidth);
+            assertEquals(null, this.mockEl.style.minWidth);
+            assertEquals(null, this.mockEl.style.maxHeight);
+            assertEquals(null, this.mockEl.style.minHeight);
             assertEquals("inline-block", this.mockEl.style.display);
         });
     };
 
     this.tests.prototype.testCheckThatRestoreRestoresCorrectCSSWhenMeasuringVertically = function (queue) {
-        expectAsserts(5);
+        expectAsserts(9);
 
         queuedRequire(queue, ["antie/widgets/label/texttruncation/cssmanager"], function(CSSManager) {
 
@@ -82,12 +94,16 @@
             assertEquals("invalidWhiteSpace", this.mockEl.style.whiteSpace);
             assertEquals("invalidWidth", this.mockEl.style.width);
             assertEquals("invalidHeight", this.mockEl.style.height);
+            assertEquals("invalidMaxWidth", this.mockEl.style.maxWidth);
+            assertEquals("invalidMinWidth", this.mockEl.style.minWidth);
+            assertEquals("invalidMaxHeight", this.mockEl.style.maxHeight);
+            assertEquals("invalidMinHeight", this.mockEl.style.minHeight);
             assertEquals("invalidDisplay", this.mockEl.style.display);
         });
     };
 
     this.tests.prototype.testCheckThatRestoreRestoresCorrectCSSWhenMeasuringHorizontally = function (queue) {
-        expectAsserts(5);
+        expectAsserts(9);
 
         queuedRequire(queue, ["antie/widgets/label/texttruncation/cssmanager"], function(CSSManager) {
 
@@ -98,6 +114,10 @@
             assertEquals("invalidWhiteSpace", this.mockEl.style.whiteSpace);
             assertEquals("invalidWidth", this.mockEl.style.width);
             assertEquals("invalidHeight", this.mockEl.style.height);
+            assertEquals("invalidMaxWidth", this.mockEl.style.maxWidth);
+            assertEquals("invalidMinWidth", this.mockEl.style.minWidth);
+            assertEquals("invalidMaxHeight", this.mockEl.style.maxHeight);
+            assertEquals("invalidMinHeight", this.mockEl.style.minHeight);
             assertEquals("invalidDisplay", this.mockEl.style.display);
         });
     };

--- a/static/script-tests/tests/widgets/label/texttruncation/helpers-test.js
+++ b/static/script-tests/tests/widgets/label/texttruncation/helpers-test.js
@@ -1,3 +1,26 @@
+/**
+ * @preserve Copyright (c) 2013 British Broadcasting Corporation
+ * (http://www.bbc.co.uk) and TAL Contributors (1)
+ *
+ * (1) TAL Contributors are listed in the AUTHORS file and at
+ *     https://github.com/fmtvp/TAL/AUTHORS - please extend this file,
+ *     not this notice.
+ *
+ * @license Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * All rights reserved
+ * Please contact us for an alternative licence
+ */
 
 (function() {
     this.tests = AsyncTestCase("Truncation Helpers");

--- a/static/script-tests/tests/widgets/label/texttruncation/helpers-test.js
+++ b/static/script-tests/tests/widgets/label/texttruncation/helpers-test.js
@@ -1,0 +1,74 @@
+
+(function() {
+    this.tests = AsyncTestCase("Truncation Helpers");
+
+    this.tests.prototype.setUp = function () {
+        this.sandbox = sinon.sandbox.create();
+        this.sourceStr = "This is a test string.";
+    };
+
+    this.tests.prototype.tearDown = function () {
+        this.sandbox.restore();
+    };
+
+    this.tests.prototype.testCheckIsAtWordBoundaryReturnsTrueWhenExpected = function (queue) {
+        expectAsserts(3);
+
+        queuedRequire(queue, ["antie/widgets/label/texttruncation/helpers"], function(Helpers) {
+            assertEquals(true, Helpers.isAtWordBoundary(this.sourceStr, 4));
+            assertEquals(true, Helpers.isAtWordBoundary(this.sourceStr, 7));
+            assertEquals(true, Helpers.isAtWordBoundary(this.sourceStr, 22));
+        });
+    };
+
+    this.tests.prototype.testCheckIsAtWordBoundaryReturnsFalseWhenExpected = function (queue) {
+        expectAsserts(2);
+
+        queuedRequire(queue, ["antie/widgets/label/texttruncation/helpers"], function(Helpers) {
+            assertEquals(false, Helpers.isAtWordBoundary(this.sourceStr, 5));
+            assertEquals(false, Helpers.isAtWordBoundary(this.sourceStr, 6));
+        });
+    };
+
+    this.tests.prototype.testCheckGetLastWordBoundaryIndexReturnsProperValueWhenStringContainsWordBoundary = function (queue) {
+        expectAsserts(1);
+
+        queuedRequire(queue, ["antie/widgets/label/texttruncation/helpers"], function(Helpers) {
+            assertEquals(14, Helpers.getLastWordBoundaryIndex(this.sourceStr));
+        });
+    };
+
+    this.tests.prototype.testCheckGetLastWordBoundaryIndexReturnsProperValueWhenStringDoesNotContainWordBoundary = function (queue) {
+        expectAsserts(1);
+
+        queuedRequire(queue, ["antie/widgets/label/texttruncation/helpers"], function(Helpers) {
+            assertEquals(-1, Helpers.getLastWordBoundaryIndex("StringWithNoWordBoundaries."));
+        });
+    };
+
+    this.tests.prototype.testCheckTrimToWordWorksProperly = function (queue) {
+        expectAsserts(4);
+
+        queuedRequire(queue, ["antie/widgets/label/texttruncation/helpers"], function(Helpers) {
+            assertEquals("This is a", Helpers.trimToWord("This is a te"));
+            assertEquals("This is a", Helpers.trimToWord("This is a "));
+            assertEquals("", Helpers.trimToWord("This"));
+            assertEquals("", Helpers.trimToWord(""));
+        });
+    };
+
+    this.tests.prototype.testCheckTrimTrailingWhitespaceWorksProperly = function (queue) {
+        expectAsserts(5);
+
+        queuedRequire(queue, ["antie/widgets/label/texttruncation/helpers"], function(Helpers) {
+            assertEquals("Test with trailing whitespace.", Helpers.trimTrailingWhitespace("Test with trailing whitespace.         "));
+            assertEquals("Testing 123.", Helpers.trimTrailingWhitespace("Testing 123."));
+            assertEquals("", Helpers.trimTrailingWhitespace(" "));
+            assertEquals("", Helpers.trimTrailingWhitespace(""));
+            assertEquals("", Helpers.trimTrailingWhitespace(""));
+        });
+    };
+
+    //TODO: test for getNoCharsThatFit
+
+})();

--- a/static/script-tests/tests/widgets/label/texttruncation/helpers-test.js
+++ b/static/script-tests/tests/widgets/label/texttruncation/helpers-test.js
@@ -35,25 +35,6 @@
         this.sandbox.restore();
     };
 
-    function setupParentContainer() {
-        var parentContainer = document.createElement("div");
-        // try and set the css to that this will render the same in all browsers
-        parentContainer.style.display = "block";
-        parentContainer.style.margin = "0";
-        parentContainer.style.padding = "0";
-        parentContainer.style.borderStyle = "none";
-        parentContainer.style.fontFamily = "Courier, monospace";
-        parentContainer.style.fontStyle = "normal";
-        parentContainer.style.fontSize = "20px";
-        parentContainer.style.fontWeight = "normal";
-        document.body.appendChild(parentContainer);
-        return parentContainer;
-    }
-
-    function destroyParentContainer(parentContainer) {
-        document.body.removeChild(parentContainer);
-    }
-
     this.tests.prototype.testCheckIsAtWordBoundaryReturnsTrueWhenExpected = function (queue) {
         expectAsserts(3);
 

--- a/static/script-tests/tests/widgets/label/texttruncation/helpers-test.js
+++ b/static/script-tests/tests/widgets/label/texttruncation/helpers-test.js
@@ -11,6 +11,25 @@
         this.sandbox.restore();
     };
 
+    function setupParentContainer() {
+        var parentContainer = document.createElement("div");
+        // try and set the css to that this will render the same in all browsers
+        parentContainer.style.display = "block";
+        parentContainer.style.margin = "0";
+        parentContainer.style.padding = "0";
+        parentContainer.style.borderStyle = "none";
+        parentContainer.style.fontFamily = "Courier, monospace";
+        parentContainer.style.fontStyle = "normal";
+        parentContainer.style.fontSize = "20px";
+        parentContainer.style.fontWeight = "normal";
+        document.body.appendChild(parentContainer);
+        return parentContainer;
+    }
+
+    function destroyParentContainer(parentContainer) {
+        document.body.removeChild(parentContainer);
+    }
+
     this.tests.prototype.testCheckIsAtWordBoundaryReturnsTrueWhenExpected = function (queue) {
         expectAsserts(3);
 
@@ -68,7 +87,5 @@
             assertEquals("", Helpers.trimTrailingWhitespace(""));
         });
     };
-
-    //TODO: test for getNoCharsThatFit
 
 })();

--- a/static/script-tests/tests/widgets/label/texttruncation/helpers-test.js
+++ b/static/script-tests/tests/widgets/label/texttruncation/helpers-test.js
@@ -2,9 +2,10 @@
 (function() {
     this.tests = AsyncTestCase("Truncation Helpers");
 
+    var TEST_STR = "This is a test string.";
+
     this.tests.prototype.setUp = function () {
         this.sandbox = sinon.sandbox.create();
-        this.sourceStr = "This is a test string.";
     };
 
     this.tests.prototype.tearDown = function () {
@@ -34,9 +35,9 @@
         expectAsserts(3);
 
         queuedRequire(queue, ["antie/widgets/label/texttruncation/helpers"], function(Helpers) {
-            assertEquals(true, Helpers.isAtWordBoundary(this.sourceStr, 4));
-            assertEquals(true, Helpers.isAtWordBoundary(this.sourceStr, 7));
-            assertEquals(true, Helpers.isAtWordBoundary(this.sourceStr, 22));
+            assertEquals(true, Helpers.isAtWordBoundary(TEST_STR, 4));
+            assertEquals(true, Helpers.isAtWordBoundary(TEST_STR, 7));
+            assertEquals(true, Helpers.isAtWordBoundary(TEST_STR, 22));
         });
     };
 
@@ -44,8 +45,8 @@
         expectAsserts(2);
 
         queuedRequire(queue, ["antie/widgets/label/texttruncation/helpers"], function(Helpers) {
-            assertEquals(false, Helpers.isAtWordBoundary(this.sourceStr, 5));
-            assertEquals(false, Helpers.isAtWordBoundary(this.sourceStr, 6));
+            assertEquals(false, Helpers.isAtWordBoundary(TEST_STR, 5));
+            assertEquals(false, Helpers.isAtWordBoundary(TEST_STR, 6));
         });
     };
 
@@ -53,7 +54,7 @@
         expectAsserts(1);
 
         queuedRequire(queue, ["antie/widgets/label/texttruncation/helpers"], function(Helpers) {
-            assertEquals(14, Helpers.getLastWordBoundaryIndex(this.sourceStr));
+            assertEquals(14, Helpers.getLastWordBoundaryIndex(TEST_STR));
         });
     };
 

--- a/static/script-tests/tests/widgets/label/texttruncation/positiongenerator-test.js
+++ b/static/script-tests/tests/widgets/label/texttruncation/positiongenerator-test.js
@@ -38,7 +38,7 @@
             assertEquals(true, positionGenerator.hasNext(true));
             assertEquals(1, positionGenerator.next(true));
         });
-    }
+    };
 
     this.tests.prototype.testCheckThatPositionGeneratorReturnsCorrectPositionAfterIsOverIsReportedFalseAndThenTrueAgainAndThenArrivesAtResult = function (queue) {
         expectAsserts(5);

--- a/static/script-tests/tests/widgets/label/texttruncation/positiongenerator-test.js
+++ b/static/script-tests/tests/widgets/label/texttruncation/positiongenerator-test.js
@@ -1,3 +1,26 @@
+/**
+ * @preserve Copyright (c) 2013 British Broadcasting Corporation
+ * (http://www.bbc.co.uk) and TAL Contributors (1)
+ *
+ * (1) TAL Contributors are listed in the AUTHORS file and at
+ *     https://github.com/fmtvp/TAL/AUTHORS - please extend this file,
+ *     not this notice.
+ *
+ * @license Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * All rights reserved
+ * Please contact us for an alternative licence
+ */
 
 (function() {
     this.tests = AsyncTestCase("Position Generator");

--- a/static/script-tests/tests/widgets/label/texttruncation/positiongenerator-test.js
+++ b/static/script-tests/tests/widgets/label/texttruncation/positiongenerator-test.js
@@ -34,12 +34,9 @@
         expectAsserts(2);
 
         queuedRequire(queue, ["antie/widgets/label/texttruncation/positiongenerator"], function (PositionGenerator) {
-
-
             positionGenerator = new PositionGenerator(9);
             assertEquals(true, positionGenerator.hasNext(true));
             assertEquals(1, positionGenerator.next(true));
-
         });
     }
 

--- a/static/script-tests/tests/widgets/label/texttruncation/positiongenerator-test.js
+++ b/static/script-tests/tests/widgets/label/texttruncation/positiongenerator-test.js
@@ -1,0 +1,68 @@
+
+(function() {
+    this.tests = AsyncTestCase("Position Generator");
+
+    this.tests.prototype.setUp = function () {
+        this.sandbox = sinon.sandbox.create();
+    };
+
+    this.tests.prototype.tearDown = function () {
+        this.sandbox.restore();
+    };
+
+    this.tests.prototype.testCheckThatPositionGeneratorReturnsCorrectNumberSequenceForDifferentLengthStrings = function (queue) {
+        expectAsserts(10 + 7 + 9 + 3 + 1 + 2 + 1);
+
+        queuedRequire(queue, ["antie/widgets/label/texttruncation/positiongenerator"], function(PositionGenerator) {
+
+            var positionGenerator;
+            positionGenerator = new PositionGenerator(8);
+            assertEquals(true, positionGenerator.hasNext(true));
+            assertEquals(4, positionGenerator.next(true));
+            assertEquals(true, positionGenerator.hasNext(true));
+            assertEquals(2, positionGenerator.calculateNext(true));
+            assertEquals(2, positionGenerator.next(true));
+            assertEquals(true, positionGenerator.hasNext(true));
+            assertEquals(1, positionGenerator.next(true));
+            assertEquals(true, positionGenerator.hasNext(true));
+            assertEquals(0, positionGenerator.next(true));
+            assertEquals(false, positionGenerator.hasNext(true));
+
+            positionGenerator = new PositionGenerator(8);
+            assertEquals(true, positionGenerator.hasNext(true));
+            assertEquals(4, positionGenerator.next(true));
+            assertEquals(true, positionGenerator.hasNext(true));
+            assertEquals(2, positionGenerator.next(true));
+            assertEquals(true, positionGenerator.hasNext(false));
+            assertEquals(3, positionGenerator.next(false));
+            assertEquals(false, positionGenerator.hasNext(false));
+
+            positionGenerator = new PositionGenerator(8);
+            assertEquals(true, positionGenerator.hasNext(true));
+            assertEquals(4, positionGenerator.next(true));
+            assertEquals(true, positionGenerator.hasNext(true));
+            assertEquals(2, positionGenerator.next(true));
+            assertEquals(true, positionGenerator.hasNext(false));
+            assertEquals(3, positionGenerator.next(false));
+            assertEquals(true, positionGenerator.hasNext(true));
+            assertEquals(2, positionGenerator.next(true));
+            assertEquals(false, positionGenerator.hasNext(false));
+
+            positionGenerator = new PositionGenerator(1);
+            assertEquals(true, positionGenerator.hasNext(true));
+            assertEquals(0, positionGenerator.next(true));
+            assertEquals(false, positionGenerator.hasNext(true));
+
+            positionGenerator = new PositionGenerator(1);
+            assertEquals(false, positionGenerator.hasNext(false));
+
+            positionGenerator = new PositionGenerator(9);
+            assertEquals(true, positionGenerator.hasNext(true));
+            assertEquals(1, positionGenerator.next(true));
+
+            positionGenerator = new PositionGenerator(0);
+            assertEquals(false, positionGenerator.hasNext(true));
+        });
+    };
+
+})();

--- a/static/script-tests/tests/widgets/label/texttruncation/positiongenerator-test.js
+++ b/static/script-tests/tests/widgets/label/texttruncation/positiongenerator-test.js
@@ -63,21 +63,28 @@
         });
     };
 
-    this.tests.prototype.testCheckThatPositionGeneratorReturnsCorrectPositionAfterIsOverIsReportedFalseAndThenTrueAgainAndThenArrivesAtResult = function (queue) {
-        expectAsserts(5);
+    this.tests.prototype.testCheckThatPositionGeneratorReturnsCorrectPositionAfterIsOverIsReportedFalse = function (queue) {
+        expectAsserts(2);
 
         queuedRequire(queue, ["antie/widgets/label/texttruncation/positiongenerator"], function (PositionGenerator) {
-            positionGenerator = new PositionGenerator(8);
-            positionGenerator.next(true);
+            positionGenerator = new PositionGenerator(4);
             positionGenerator.next(true);
             assertEquals(true, positionGenerator.hasNext(false));
             assertEquals(3, positionGenerator.next(false));
-            assertEquals(true, positionGenerator.hasNext(true));
-            assertEquals(2, positionGenerator.next(true));
-            assertEquals(false, positionGenerator.hasNext(false));
         });
     };
 
+    this.tests.prototype.testCheckThatPositionGeneratorReturnsDecreasingValueAfterPointerHasReachedZero = function (queue) {
+        expectAsserts(2);
+
+        queuedRequire(queue, ["antie/widgets/label/texttruncation/positiongenerator"], function (PositionGenerator) {
+            positionGenerator = new PositionGenerator(4);
+            positionGenerator.next(true);
+            positionGenerator.next(false);
+            assertEquals(true, positionGenerator.hasNext(true));
+            assertEquals(2, positionGenerator.next(true));
+        });
+    };
 
     this.tests.prototype.testCheckThatPositionGeneratorReturnsFalseFromHasNextWhenIsOverAndCheckingStringOfLengthZero = function (queue) {
         expectAsserts(1);

--- a/static/script-tests/tests/widgets/label/texttruncation/positiongenerator-test.js
+++ b/static/script-tests/tests/widgets/label/texttruncation/positiongenerator-test.js
@@ -10,17 +10,16 @@
         this.sandbox.restore();
     };
 
-    this.tests.prototype.testCheckThatPositionGeneratorReturnsCorrectNumberSequenceForDifferentLengthStrings = function (queue) {
-        expectAsserts(10 + 7 + 9 + 3 + 1 + 2 + 1);
+    this.tests.prototype.testCheckThatPositionGeneratorReturnsCorrectNumberSequence = function (queue) {
+        expectAsserts(9);
 
-        queuedRequire(queue, ["antie/widgets/label/texttruncation/positiongenerator"], function(PositionGenerator) {
+        queuedRequire(queue, ["antie/widgets/label/texttruncation/positiongenerator"], function (PositionGenerator) {
 
             var positionGenerator;
             positionGenerator = new PositionGenerator(8);
             assertEquals(true, positionGenerator.hasNext(true));
             assertEquals(4, positionGenerator.next(true));
             assertEquals(true, positionGenerator.hasNext(true));
-            assertEquals(2, positionGenerator.calculateNext(true));
             assertEquals(2, positionGenerator.next(true));
             assertEquals(true, positionGenerator.hasNext(true));
             assertEquals(1, positionGenerator.next(true));
@@ -28,38 +27,42 @@
             assertEquals(0, positionGenerator.next(true));
             assertEquals(false, positionGenerator.hasNext(true));
 
-            positionGenerator = new PositionGenerator(8);
-            assertEquals(true, positionGenerator.hasNext(true));
-            assertEquals(4, positionGenerator.next(true));
-            assertEquals(true, positionGenerator.hasNext(true));
-            assertEquals(2, positionGenerator.next(true));
-            assertEquals(true, positionGenerator.hasNext(false));
-            assertEquals(3, positionGenerator.next(false));
-            assertEquals(false, positionGenerator.hasNext(false));
+        });
+    };
 
-            positionGenerator = new PositionGenerator(8);
-            assertEquals(true, positionGenerator.hasNext(true));
-            assertEquals(4, positionGenerator.next(true));
-            assertEquals(true, positionGenerator.hasNext(true));
-            assertEquals(2, positionGenerator.next(true));
-            assertEquals(true, positionGenerator.hasNext(false));
-            assertEquals(3, positionGenerator.next(false));
-            assertEquals(true, positionGenerator.hasNext(true));
-            assertEquals(2, positionGenerator.next(true));
-            assertEquals(false, positionGenerator.hasNext(false));
+    this.tests.prototype.testCheckThatPositionGeneratorReturnsCorrectFirstPositionWithStringLengthIsNotAPowerOfTwo = function (queue) {
+        expectAsserts(2);
 
-            positionGenerator = new PositionGenerator(1);
-            assertEquals(true, positionGenerator.hasNext(true));
-            assertEquals(0, positionGenerator.next(true));
-            assertEquals(false, positionGenerator.hasNext(true));
+        queuedRequire(queue, ["antie/widgets/label/texttruncation/positiongenerator"], function (PositionGenerator) {
 
-            positionGenerator = new PositionGenerator(1);
-            assertEquals(false, positionGenerator.hasNext(false));
 
             positionGenerator = new PositionGenerator(9);
             assertEquals(true, positionGenerator.hasNext(true));
             assertEquals(1, positionGenerator.next(true));
 
+        });
+    }
+
+    this.tests.prototype.testCheckThatPositionGeneratorReturnsCorrectPositionAfterIsOverIsReportedFalseAndThenTrueAgainAndThenArrivesAtResult = function (queue) {
+        expectAsserts(5);
+
+        queuedRequire(queue, ["antie/widgets/label/texttruncation/positiongenerator"], function (PositionGenerator) {
+            positionGenerator = new PositionGenerator(8);
+            positionGenerator.next(true);
+            positionGenerator.next(true);
+            assertEquals(true, positionGenerator.hasNext(false));
+            assertEquals(3, positionGenerator.next(false));
+            assertEquals(true, positionGenerator.hasNext(true));
+            assertEquals(2, positionGenerator.next(true));
+            assertEquals(false, positionGenerator.hasNext(false));
+        });
+    };
+
+
+    this.tests.prototype.testCheckThatPositionGeneratorReturnsFalseFromHasNextWhenIsOverAndCheckingStringOfLengthZero = function (queue) {
+        expectAsserts(1);
+
+        queuedRequire(queue, ["antie/widgets/label/texttruncation/positiongenerator"], function (PositionGenerator) {
             positionGenerator = new PositionGenerator(0);
             assertEquals(false, positionGenerator.hasNext(true));
         });

--- a/static/script-tests/tests/widgets/label/texttruncation/truncator-test.js
+++ b/static/script-tests/tests/widgets/label/texttruncation/truncator-test.js
@@ -1,3 +1,26 @@
+/**
+ * @preserve Copyright (c) 2013 British Broadcasting Corporation
+ * (http://www.bbc.co.uk) and TAL Contributors (1)
+ *
+ * (1) TAL Contributors are listed in the AUTHORS file and at
+ *     https://github.com/fmtvp/TAL/AUTHORS - please extend this file,
+ *     not this notice.
+ *
+ * @license Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * All rights reserved
+ * Please contact us for an alternative licence
+ */
 
 (function() {
     this.tests = AsyncTestCase("Truncator");

--- a/static/script-tests/tests/widgets/label/texttruncation/truncator-test.js
+++ b/static/script-tests/tests/widgets/label/texttruncation/truncator-test.js
@@ -34,28 +34,40 @@
     };
 
     var SAMPLE_TEXT = "This is some sample text.";
-    var numberOfCharactersToReturnFromWorkContainer;
 
     function stubWorkContainer(sandbox, WorkContainer) {
-        sandbox.stub(WorkContainer.prototype, "init", function() {});
-        sandbox.stub(WorkContainer.prototype, "destroy", function() {});
-        sandbox.stub(WorkContainer.prototype, "getNumCharactersThatFit", function(txt) {
-            // pretend that it's always numberToReturn characters that fit or the entire string
-            return txt.length < numberOfCharactersToReturnFromWorkContainer ? txt.length : numberOfCharactersToReturnFromWorkContainer;
-        });
+        sandbox.stub(WorkContainer.prototype, "init");
+        sandbox.stub(WorkContainer.prototype, "destroy");
+        sandbox.stub(WorkContainer.prototype, "getNumCharactersThatFit");
     }
 
-    this.tests.prototype.testCheckGetEllipsisIfNecessaryReturnsCorrectValues = function (queue) {
-        expectAsserts(3);
+    this.tests.prototype.testCheckGetEllipsisIfNecessaryReturnsCorrectValueWhenNotOnLastLine = function (queue) {
+        expectAsserts(1);
 
         queuedRequire(queue, ["antie/widgets/label/texttruncation/truncator"], function(Truncator) {
-
             var truncator = new Truncator();
             assertEquals("", truncator._getEllipsisIfNecessary(3, 1));
+        });
+    };
+
+    this.tests.prototype.testCheckGetEllipsisIfNecessaryReturnsCorrectValueWhenOnLastLine = function (queue) {
+        expectAsserts(1);
+
+        queuedRequire(queue, ["antie/widgets/label/texttruncation/truncator"], function(Truncator) {
+            var truncator = new Truncator();
             assertEquals("...", truncator._getEllipsisIfNecessary(3, 2));
+        });
+    };
+
+    this.tests.prototype.testCheckGetEllipsisIfNecessaryReturnsCorrectValueWhenFillingContainer = function (queue) {
+        expectAsserts(1);
+
+        queuedRequire(queue, ["antie/widgets/label/texttruncation/truncator"], function(Truncator) {
+            var truncator = new Truncator();
             assertEquals("...", truncator._getEllipsisIfNecessary(0, 0));
         });
     };
+
 
     this.tests.prototype.testCheckTextIsTruncatedToCorrectAmountWhenSplittingAtWordBoundaryAndUsingEllipsisText = function (queue) {
         expectAsserts(3);
@@ -70,13 +82,14 @@
             truncator.setEllipsisText("...");
             truncator.setSplitAtWordBoundary(true);
 
-            numberOfCharactersToReturnFromWorkContainer = 10;
+            WorkContainer.prototype.getNumCharactersThatFit.returns(10);
+
             assertEquals("This is...", truncator.truncateText(null, SAMPLE_TEXT, 0));
 
-            numberOfCharactersToReturnFromWorkContainer = SAMPLE_TEXT.length;
+            WorkContainer.prototype.getNumCharactersThatFit.returns(SAMPLE_TEXT.length);
             assertEquals(SAMPLE_TEXT, truncator.truncateText(null, SAMPLE_TEXT, 0));
 
-            numberOfCharactersToReturnFromWorkContainer = SAMPLE_TEXT.length-1;
+            WorkContainer.prototype.getNumCharactersThatFit.returns(SAMPLE_TEXT.length-1);
             assertEquals("This is some sample...", truncator.truncateText(null, SAMPLE_TEXT, 0));
         });
     };
@@ -94,10 +107,31 @@
             truncator.setEllipsisText("...");
             truncator.setSplitAtWordBoundary(false);
 
-            numberOfCharactersToReturnFromWorkContainer = 10;
+            WorkContainer.prototype.getNumCharactersThatFit.returns(10);
             assertEquals("This is so...", truncator.truncateText(null, SAMPLE_TEXT, 0));
 
-            numberOfCharactersToReturnFromWorkContainer = SAMPLE_TEXT.length;
+            WorkContainer.prototype.getNumCharactersThatFit.returns(SAMPLE_TEXT.length);
+            assertEquals(SAMPLE_TEXT, truncator.truncateText(null, SAMPLE_TEXT, 0));
+        });
+    };
+
+    this.tests.prototype.testCheckTextIsTruncatedToCorrectAmountWhenSplittingAtWordBoundaryAndNotUsingEllipsisText = function (queue) {
+        expectAsserts(2);
+
+        queuedRequire(queue, ["antie/widgets/label/texttruncation/truncator",
+                "antie/widgets/label/texttruncation/workcontainer"],
+        function(Truncator, WorkContainer) {
+            stubWorkContainer(this.sandbox, WorkContainer);
+
+            var truncator = new Truncator();
+
+            truncator.setEllipsisText("");
+            truncator.setSplitAtWordBoundary(true);
+
+            WorkContainer.prototype.getNumCharactersThatFit.returns(10);
+            assertEquals("This is", truncator.truncateText(null, SAMPLE_TEXT, 0));
+
+            WorkContainer.prototype.getNumCharactersThatFit.returns(SAMPLE_TEXT.length);
             assertEquals(SAMPLE_TEXT, truncator.truncateText(null, SAMPLE_TEXT, 0));
         });
     };
@@ -115,10 +149,10 @@
             truncator.setEllipsisText("");
             truncator.setSplitAtWordBoundary(false);
 
-            numberOfCharactersToReturnFromWorkContainer = 10;
+            WorkContainer.prototype.getNumCharactersThatFit.returns(10);
             assertEquals("This is so", truncator.truncateText(null, SAMPLE_TEXT, 0));
 
-            numberOfCharactersToReturnFromWorkContainer = SAMPLE_TEXT.length;
+            WorkContainer.prototype.getNumCharactersThatFit.returns(SAMPLE_TEXT.length);
             assertEquals(SAMPLE_TEXT, truncator.truncateText(null, SAMPLE_TEXT, 0));
         });
     };

--- a/static/script-tests/tests/widgets/label/texttruncation/truncator-test.js
+++ b/static/script-tests/tests/widgets/label/texttruncation/truncator-test.js
@@ -1,0 +1,104 @@
+
+(function() {
+    this.tests = AsyncTestCase("Truncator");
+
+    this.tests.prototype.setUp = function () {
+        this.sandbox = sinon.sandbox.create();
+    };
+
+    this.tests.prototype.tearDown = function () {
+        this.sandbox.restore();
+    };
+
+    var SAMPLE_TEXT = "This is some sample text.";
+    var numberOfCharactersToReturnFromWorkContainer;
+
+    function stubWorkContainer(sandbox, WorkContainer) {
+        sandbox.stub(WorkContainer.prototype, "init", function() {});
+        sandbox.stub(WorkContainer.prototype, "destroy", function() {});
+        sandbox.stub(WorkContainer.prototype, "getNumCharactersThatFit", function(txt) {
+            // pretend that it's always numberToReturn characters that fit or the entire string
+            return txt.length < numberOfCharactersToReturnFromWorkContainer ? txt.length : numberOfCharactersToReturnFromWorkContainer;
+        });
+    }
+
+    this.tests.prototype.testCheckGetEllipsisIfNecessaryReturnsCorrectValues = function (queue) {
+        expectAsserts(3);
+
+        queuedRequire(queue, ["antie/widgets/label/texttruncation/truncator"], function(Truncator) {
+
+            var truncator = new Truncator();
+            assertEquals("", truncator._getEllipsisIfNecessary(3, 1));
+            assertEquals("...", truncator._getEllipsisIfNecessary(3, 2));
+            assertEquals("...", truncator._getEllipsisIfNecessary(0, 0));
+        });
+    };
+
+    this.tests.prototype.testCheckTextIsTruncatedToCorrectAmountWhenSplittingAtWordBoundaryAndUsingEllipsisText = function (queue) {
+        expectAsserts(3);
+
+        queuedRequire(queue, ["antie/widgets/label/texttruncation/truncator",
+                              "antie/widgets/label/texttruncation/workcontainer"],
+        function(Truncator, WorkContainer) {
+            stubWorkContainer(this.sandbox, WorkContainer);
+
+            var truncator = new Truncator();
+
+            truncator.setEllipsisText("...");
+            truncator.setSplitAtWordBoundary(true);
+
+            numberOfCharactersToReturnFromWorkContainer = 10;
+            assertEquals("This is...", truncator.truncateText(null, SAMPLE_TEXT, 0));
+
+            numberOfCharactersToReturnFromWorkContainer = SAMPLE_TEXT.length;
+            assertEquals(SAMPLE_TEXT, truncator.truncateText(null, SAMPLE_TEXT, 0));
+
+            numberOfCharactersToReturnFromWorkContainer = SAMPLE_TEXT.length-1;
+            assertEquals("This is some sample...", truncator.truncateText(null, SAMPLE_TEXT, 0));
+        });
+    };
+
+    this.tests.prototype.testCheckTextIsTruncatedToCorrectAmountWhenNotSplittingAtWordBoundaryAndUsingEllipsisText = function (queue) {
+        expectAsserts(2);
+
+        queuedRequire(queue, ["antie/widgets/label/texttruncation/truncator",
+                "antie/widgets/label/texttruncation/workcontainer"],
+        function(Truncator, WorkContainer) {
+            stubWorkContainer(this.sandbox, WorkContainer);
+
+            var truncator = new Truncator();
+
+            truncator.setEllipsisText("...");
+            truncator.setSplitAtWordBoundary(false);
+
+            numberOfCharactersToReturnFromWorkContainer = 10;
+            assertEquals("This is so...", truncator.truncateText(null, SAMPLE_TEXT, 0));
+
+            numberOfCharactersToReturnFromWorkContainer = SAMPLE_TEXT.length;
+            assertEquals(SAMPLE_TEXT, truncator.truncateText(null, SAMPLE_TEXT, 0));
+        });
+    };
+
+    this.tests.prototype.testCheckTextIsTruncatedToCorrectAmountWhenNotSplittingAtWordBoundaryAndNotUsingEllipsisText = function (queue) {
+        expectAsserts(2);
+
+        queuedRequire(queue, ["antie/widgets/label/texttruncation/truncator",
+                "antie/widgets/label/texttruncation/workcontainer"],
+        function(Truncator, WorkContainer) {
+            stubWorkContainer(this.sandbox, WorkContainer);
+
+            var truncator = new Truncator();
+
+            truncator.setEllipsisText("");
+            truncator.setSplitAtWordBoundary(false);
+
+            numberOfCharactersToReturnFromWorkContainer = 10;
+            assertEquals("This is so", truncator.truncateText(null, SAMPLE_TEXT, 0));
+
+            numberOfCharactersToReturnFromWorkContainer = SAMPLE_TEXT.length;
+            assertEquals(SAMPLE_TEXT, truncator.truncateText(null, SAMPLE_TEXT, 0));
+        });
+    };
+
+
+})();

--- a/static/script-tests/tests/widgets/label/texttruncation/workcontainer-test.js
+++ b/static/script-tests/tests/widgets/label/texttruncation/workcontainer-test.js
@@ -2,10 +2,19 @@
 (function() {
     this.tests = AsyncTestCase("Work Container");
 
+    var LOREM_IPSUM = "Donec dignissim lacus eu quam fringilla, vitae hendrerit tellus egestas. Aenean ultricies blandit tellus, ac vestibulum libero sagittis in. Integer purus tortor, placerat quis velit ac, pulvinar sodales augue. Maecenas sodales, arcu id aliquet consectetur, enim purus lacinia urna, nec sagittis sem elit a nunc. Nam sagittis molestie varius. Aliquam vehicula, nisi ut porta venenatis, diam ipsum sodales nisi, nec rhoncus lorem quam sit amet neque. Cras euismod porttitor felis, at pulvinar diam iaculis vel. Nullam tincidunt turpis sit amet nunc lacinia, a fermentum purus tincidunt. Curabitur ac elit a quam posuere fermentum in sit amet ante. Vivamus semper ligula non metus mattis, id feugiat mauris ultrices. Aliquam ullamcorper molestie metus eget laoreet. Sed gravida mi et mauris venenatis, nec ultricies lacus suscipit. Nullam placerat elit id euismod interdum. Proin et dui eget sem sodales bibendum. Nam pulvinar, libero id elementum sagittis, purus augue molestie dui, vel dapibus lorem nibh ac odio. In eu adipiscing sapien.";
+    var SHORT_TEXT = "Two words.";
+
+    var container;
+
     this.tests.prototype.setUp = function () {
         this.sandbox = sinon.sandbox.create();
-        this.sourceText = "Donec dignissim lacus eu quam fringilla, vitae hendrerit tellus egestas. Aenean ultricies blandit tellus, ac vestibulum libero sagittis in. Integer purus tortor, placerat quis velit ac, pulvinar sodales augue. Maecenas sodales, arcu id aliquet consectetur, enim purus lacinia urna, nec sagittis sem elit a nunc. Nam sagittis molestie varius. Aliquam vehicula, nisi ut porta venenatis, diam ipsum sodales nisi, nec rhoncus lorem quam sit amet neque. Cras euismod porttitor felis, at pulvinar diam iaculis vel. Nullam tincidunt turpis sit amet nunc lacinia, a fermentum purus tincidunt. Curabitur ac elit a quam posuere fermentum in sit amet ante. Vivamus semper ligula non metus mattis, id feugiat mauris ultrices. Aliquam ullamcorper molestie metus eget laoreet. Sed gravida mi et mauris venenatis, nec ultricies lacus suscipit. Nullam placerat elit id euismod interdum. Proin et dui eget sem sodales bibendum. Nam pulvinar, libero id elementum sagittis, purus augue molestie dui, vel dapibus lorem nibh ac odio. In eu adipiscing sapien.";
         this.parentContainer = setupParentContainer();
+
+        container = document.createElement("div");
+        this.parentContainer.appendChild(container);
+        container.style.width = "100px";
+        container.style.height = "100px";
     };
 
     this.tests.prototype.tearDown = function () {
@@ -28,20 +37,16 @@
         return container;
     }
 
-    function destroyParentContainer(container) {
-        document.body.removeChild(container);
+    function destroyParentContainer(parentContainer) {
+        document.body.removeChild(parentContainer);
     }
 
     this.tests.prototype.testCheckTextThatIsMoreThanContainersVerticalHeightWhenMeasuringVerticallyIsReportedAsOver = function (queue) {
         expectAsserts(1);
 
         queuedRequire(queue, ["antie/widgets/label/texttruncation/workcontainer"], function(WorkContainer) {
-            var container = document.createElement("div");
-            this.parentContainer.appendChild(container);
-            container.style.width = "100px";
-            container.style.height = "100px";
             var workContainer = new WorkContainer(container, false);
-            assertEquals(true, workContainer.isOver(this.sourceText));
+            assertEquals(true, workContainer.isOver(LOREM_IPSUM));
         });
     };
 
@@ -49,12 +54,8 @@
         expectAsserts(1);
 
         queuedRequire(queue, ["antie/widgets/label/texttruncation/workcontainer"], function(WorkContainer) {
-            var container = document.createElement("div");
-            this.parentContainer.appendChild(container);
-            container.style.width = "100px";
-            container.style.height = "100px";
             var workContainer = new WorkContainer(container, false);
-            assertEquals(false, workContainer.isOver("Two words."));
+            assertEquals(false, workContainer.isOver(SHORT_TEXT));
         });
     };
 
@@ -62,12 +63,8 @@
         expectAsserts(1);
 
         queuedRequire(queue, ["antie/widgets/label/texttruncation/workcontainer"], function(WorkContainer) {
-            var container = document.createElement("div");
-            this.parentContainer.appendChild(container);
-            container.style.width = "100px";
-            container.style.height = "100px";
             var workContainer = new WorkContainer(container, true);
-            assertEquals(true, workContainer.isOver(this.sourceText));
+            assertEquals(true, workContainer.isOver(LOREM_IPSUM));
         });
     };
 
@@ -75,12 +72,20 @@
         expectAsserts(1);
 
         queuedRequire(queue, ["antie/widgets/label/texttruncation/workcontainer"], function(WorkContainer) {
-            var container = document.createElement("div");
-            this.parentContainer.appendChild(container);
-            container.style.width = "100px";
-            container.style.height = "100px";
             var workContainer = new WorkContainer(container, true);
-            assertEquals(true, workContainer.isOver("Two words."));
+            assertEquals(true, workContainer.isOver(SHORT_TEXT));
+        });
+    };
+
+    this.tests.prototype.testDestroyRemovesChildContainerFromParent = function (queue) {
+        expectAsserts(3);
+
+        queuedRequire(queue, ["antie/widgets/label/texttruncation/workcontainer"], function(WorkContainer) {
+            assertEquals(0, container.childNodes.length);
+            var workContainer = new WorkContainer(container, true);
+            assertEquals(1, container.childNodes.length);
+            workContainer.destroy();
+            assertEquals(0, container.childNodes.length);
         });
     };
 

--- a/static/script-tests/tests/widgets/label/texttruncation/workcontainer-test.js
+++ b/static/script-tests/tests/widgets/label/texttruncation/workcontainer-test.js
@@ -23,18 +23,18 @@
     };
 
     function setupParentContainer() {
-        var container = document.createElement("div");
+        var parentContainer = document.createElement("div");
         // try and set the css to that this will render the same in all browsers
-        container.style.display = "block";
-        container.style.margin = "0";
-        container.style.padding = "0";
-        container.style.borderStyle = "none";
-        container.style.fontFamily = "Courier, monospace";
-        container.style.fontStyle = "normal";
-        container.style.fontSize = "20px";
-        container.style.fontWeight = "normal";
-        document.body.appendChild(container);
-        return container;
+        parentContainer.style.display = "block";
+        parentContainer.style.margin = "0";
+        parentContainer.style.padding = "0";
+        parentContainer.style.borderStyle = "none";
+        parentContainer.style.fontFamily = "Courier, monospace";
+        parentContainer.style.fontStyle = "normal";
+        parentContainer.style.fontSize = "20px";
+        parentContainer.style.fontWeight = "normal";
+        document.body.appendChild(parentContainer);
+        return parentContainer;
     }
 
     function destroyParentContainer(parentContainer) {

--- a/static/script-tests/tests/widgets/label/texttruncation/workcontainer-test.js
+++ b/static/script-tests/tests/widgets/label/texttruncation/workcontainer-test.js
@@ -115,7 +115,7 @@
             stubWorkContainer(this.sandbox, WorkContainer, mockContainer);
 
             var workContainer = new WorkContainer(application.getDevice(), getMockDomContainer(), false);
-            fakeSizeOfContainerThatIsCollapsingAroundContent(mockContainer, 100, 100);
+            fakeSizeOfContainerThatIsCollapsingAroundContent(mockContainer, 100, 99);
 
             assertEquals(false, workContainer.isOver(""));
         });
@@ -159,10 +159,32 @@
             stubWorkContainer(this.sandbox, WorkContainer, mockContainer);
 
             var workContainer = new WorkContainer(application.getDevice(), getMockDomContainer(), true);
-            fakeSizeOfContainerThatIsCollapsingAroundContent(mockContainer, 100, 100);
+            fakeSizeOfContainerThatIsCollapsingAroundContent(mockContainer, 99, 100);
 
             assertEquals(false, workContainer.isOver(""));
         });
+    };
+
+    this.tests.prototype.testCheckThatIsOverReturnsTrueWhenBothValuesTheSame = function (queue) {
+        expectAsserts(1);
+
+        queuedApplicationInit(
+            queue,
+            "lib/mockapplication",
+            ["antie/widgets/label/texttruncation/workcontainer",
+                "antie/widgets/label/texttruncation/cssmanager"],
+            function(application, WorkContainer, CssManager) {
+
+                var mockContainer = getMockDomContainer(100, 100);
+
+                stubCssManager(this.sandbox, CssManager);
+                stubWorkContainer(this.sandbox, WorkContainer, mockContainer);
+
+                var workContainer = new WorkContainer(application.getDevice(), getMockDomContainer(), true);
+                fakeSizeOfContainerThatIsCollapsingAroundContent(mockContainer, 100, 100);
+
+                assertEquals(true, workContainer.isOver(""));
+            });
     };
 
 

--- a/static/script-tests/tests/widgets/label/texttruncation/workcontainer-test.js
+++ b/static/script-tests/tests/widgets/label/texttruncation/workcontainer-test.js
@@ -36,24 +36,18 @@
     var LOREM_IPSUM = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque sagittis lacus ac urna tempus molestie. Etiam dignissim at arcu eu tincidunt. Cras molestie sed lacus eget ultrices. Donec fringilla auctor lacus non sagittis. Vivamus egestas eros massa, a bibendum augue ullamcorper a. Praesent ut lacus pulvinar, ullamcorper felis vel, volutpat leo. Nullam luctus vel justo eu commodo. Maecenas elementum felis elit, a aliquet dui lacinia elementum. Aenean non dolor scelerisque leo malesuada laoreet nec ac turpis. Nunc dapibus at risus id malesuada. Donec eu nisi vitae lorem elementum lobortis. Interdum et malesuada fames ac ante ipsum primis in faucibus. Donec ultricies congue quam quis condimentum. Aliquam commodo iaculis eros, ut tincidunt neque gravida quis. Maecenas a augue a ipsum luctus fermentum. Cras sit amet purus at nisi vestibulum pulvinar.";
 
     function stubCssManager(sandbox, CssManager) {
-        sandbox.stub(CssManager.prototype, "init", function() {});
-        sandbox.stub(CssManager.prototype, "restore", function() {});
+        sandbox.stub(CssManager.prototype, "init");
+        sandbox.stub(CssManager.prototype, "restore");
     }
 
     function stubWorkContainer(sandbox, WorkContainer, sourceContainer) {
-        sandbox.stub(WorkContainer.prototype, "_createContainer", function() {
-            return sourceContainer;
-        });
-
-        sandbox.stub(WorkContainer.prototype, "_createTxtTruncationElNode", function() {
-            return getMockDomTextNode("");
-        });
+        sandbox.stub(WorkContainer.prototype, "_createContainer").returns(sourceContainer);
+        sandbox.stub(WorkContainer.prototype, "_createTxtTruncationElNode").returns(getMockDomTextNode(""));
     }
 
     function stubPositionGenerator(sandbox, PositionGenerator) {
         var positionGeneratorResults = [8, 4, 6];
-        sandbox.stub(PositionGenerator.prototype, "init", function () {
-        });
+        sandbox.stub(PositionGenerator.prototype, "init");
         sandbox.stub(PositionGenerator.prototype, "hasNext", function () {
             return positionGeneratorResults.length > 0;
         });
@@ -78,6 +72,10 @@
         };
     }
 
+    function fakeSizeOfContainerThatIsCollapsingAroundContent(mockContainer, w, h) {
+        mockContainer.clientWidth = mockContainer.offsetWidth = w;
+        mockContainer.clientHeight = mockContainer.offsetHeight = h;
+    }
 
     this.tests.prototype.testCheckTextThatIsMoreThanContainersVerticalHeightWhenMeasuringVerticallyIsReportedAsOver = function (queue) {
         expectAsserts(1);
@@ -95,7 +93,7 @@
             stubWorkContainer(this.sandbox, WorkContainer, mockContainer);
 
             var workContainer = new WorkContainer(application.getDevice(), getMockDomContainer(), false);
-            mockContainer.clientHeight = mockContainer.offsetHeight = 150;
+            fakeSizeOfContainerThatIsCollapsingAroundContent(mockContainer, 100, 101);
 
             assertEquals(true, workContainer.isOver(""));
         });
@@ -117,7 +115,7 @@
             stubWorkContainer(this.sandbox, WorkContainer, mockContainer);
 
             var workContainer = new WorkContainer(application.getDevice(), getMockDomContainer(), false);
-            mockContainer.clientHeight = mockContainer.offsetHeight = 50;
+            fakeSizeOfContainerThatIsCollapsingAroundContent(mockContainer, 100, 100);
 
             assertEquals(false, workContainer.isOver(""));
         });
@@ -139,7 +137,7 @@
             stubWorkContainer(this.sandbox, WorkContainer, mockContainer);
 
             var workContainer = new WorkContainer(application.getDevice(), getMockDomContainer(), true);
-            mockContainer.clientWidth = mockContainer.offsetWidth = 150;
+            fakeSizeOfContainerThatIsCollapsingAroundContent(mockContainer, 101, 100);
 
             assertEquals(true, workContainer.isOver(""));
         });
@@ -161,7 +159,7 @@
             stubWorkContainer(this.sandbox, WorkContainer, mockContainer);
 
             var workContainer = new WorkContainer(application.getDevice(), getMockDomContainer(), true);
-            mockContainer.clientWidth = mockContainer.offsetWidth = 50;
+            fakeSizeOfContainerThatIsCollapsingAroundContent(mockContainer, 100, 100);
 
             assertEquals(false, workContainer.isOver(""));
         });

--- a/static/script-tests/tests/widgets/label/texttruncation/workcontainer-test.js
+++ b/static/script-tests/tests/widgets/label/texttruncation/workcontainer-test.js
@@ -1,3 +1,26 @@
+/**
+ * @preserve Copyright (c) 2013 British Broadcasting Corporation
+ * (http://www.bbc.co.uk) and TAL Contributors (1)
+ *
+ * (1) TAL Contributors are listed in the AUTHORS file and at
+ *     https://github.com/fmtvp/TAL/AUTHORS - please extend this file,
+ *     not this notice.
+ *
+ * @license Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * All rights reserved
+ * Please contact us for an alternative licence
+ */
 
 (function() {
     this.tests = AsyncTestCase("Work Container");

--- a/static/script-tests/tests/widgets/label/texttruncation/workcontainer-test.js
+++ b/static/script-tests/tests/widgets/label/texttruncation/workcontainer-test.js
@@ -10,9 +10,6 @@
     this.tests.prototype.setUp = function () {
         this.sandbox = sinon.sandbox.create();
         this.parentContainer = setupParentContainer();
-
-
-
         container = document.createElement("div");
         this.parentContainer.appendChild(container);
         container.style.width = "100px";
@@ -46,8 +43,12 @@
     this.tests.prototype.testCheckTextThatIsMoreThanContainersVerticalHeightWhenMeasuringVerticallyIsReportedAsOver = function (queue) {
         expectAsserts(1);
 
-        queuedRequire(queue, ["antie/widgets/label/texttruncation/workcontainer"], function(WorkContainer) {
-            var workContainer = new WorkContainer(container, false);
+        queuedApplicationInit(
+            queue,
+            "lib/mockapplication",
+            ["antie/widgets/label/texttruncation/workcontainer"],
+        function(application, WorkContainer) {
+            var workContainer = new WorkContainer(application.getDevice(), container, false);
             assertEquals(true, workContainer.isOver(LOREM_IPSUM));
         });
     };
@@ -55,8 +56,12 @@
     this.tests.prototype.testCheckTextThatIsLessThanContainersHeightWhenMeasuringVerticallyIsNotReportedAsOver = function (queue) {
         expectAsserts(1);
 
-        queuedRequire(queue, ["antie/widgets/label/texttruncation/workcontainer"], function(WorkContainer) {
-            var workContainer = new WorkContainer(container, false);
+        queuedApplicationInit(
+            queue,
+            "lib/mockapplication",
+            ["antie/widgets/label/texttruncation/workcontainer"],
+        function(application, WorkContainer) {
+            var workContainer = new WorkContainer(application.getDevice(), container, false);
             assertEquals(false, workContainer.isOver(SHORT_TEXT));
         });
     };
@@ -64,8 +69,12 @@
     this.tests.prototype.testCheckTextThatIsMoreThanContainersWidthWhenMeasuringHorizontallyIsReportedAsOver = function (queue) {
         expectAsserts(1);
 
-        queuedRequire(queue, ["antie/widgets/label/texttruncation/workcontainer"], function(WorkContainer) {
-            var workContainer = new WorkContainer(container, true);
+        queuedApplicationInit(
+            queue,
+            "lib/mockapplication",
+            ["antie/widgets/label/texttruncation/workcontainer"],
+        function(application, WorkContainer) {
+            var workContainer = new WorkContainer(application.getDevice(), container, true);
             assertEquals(true, workContainer.isOver(LOREM_IPSUM));
         });
     };
@@ -73,8 +82,12 @@
     this.tests.prototype.testCheckTextThatIsLessThanContainersWidthWhenMeasuringHorizontallyIsNotReportedAsOver = function (queue) {
         expectAsserts(1);
 
-        queuedRequire(queue, ["antie/widgets/label/texttruncation/workcontainer"], function(WorkContainer) {
-            var workContainer = new WorkContainer(container, true);
+        queuedApplicationInit(
+            queue,
+            "lib/mockapplication",
+            ["antie/widgets/label/texttruncation/workcontainer"],
+        function(application, WorkContainer) {
+            var workContainer = new WorkContainer(application.getDevice(), container, true);
             assertEquals(true, workContainer.isOver(SHORT_TEXT));
         });
     };
@@ -82,9 +95,13 @@
     this.tests.prototype.testCheckDestroyRemovesChildContainerFromParent = function (queue) {
         expectAsserts(3);
 
-        queuedRequire(queue, ["antie/widgets/label/texttruncation/workcontainer"], function(WorkContainer) {
+        queuedApplicationInit(
+            queue,
+            "lib/mockapplication",
+            ["antie/widgets/label/texttruncation/workcontainer"],
+        function(application, WorkContainer) {
             assertEquals(0, container.childNodes.length);
-            var workContainer = new WorkContainer(container, true);
+            var workContainer = new WorkContainer(application.getDevice(), container, true);
             assertEquals(1, container.childNodes.length);
             workContainer.destroy();
             assertEquals(0, container.childNodes.length);
@@ -94,10 +111,12 @@
     this.tests.prototype.testCheckGetNumCharactersThatFitReturnsCorrectValuesWhenMeasuringVertically = function (queue) {
         expectAsserts(2);
 
-        queuedRequire(queue, ["antie/widgets/label/texttruncation/workcontainer"], function(WorkContainer) {
-            var workContainer = new WorkContainer(container, false);
-            //TODO
-            this.sandbox.stub(workContainer, "_create").returns({});
+        queuedApplicationInit(
+            queue,
+            "lib/mockapplication",
+            ["antie/widgets/label/texttruncation/workcontainer"],
+        function(application, WorkContainer) {
+            var workContainer = new WorkContainer(application.getDevice(), container, false);
             assertEquals(30, workContainer.getNumCharactersThatFit(LOREM_IPSUM, "..."));
             assertEquals(33, workContainer.getNumCharactersThatFit(LOREM_IPSUM, ""));
         });
@@ -106,8 +125,12 @@
     this.tests.prototype.testCheckGetNumCharactersThatFitReturnsCorrectValuesWhenMeasuringHorizontally = function (queue) {
         expectAsserts(2);
 
-        queuedRequire(queue, ["antie/widgets/label/texttruncation/workcontainer"], function(WorkContainer) {
-            var workContainer = new WorkContainer(container, true);
+        queuedApplicationInit(
+            queue,
+            "lib/mockapplication",
+            ["antie/widgets/label/texttruncation/workcontainer"],
+        function(application, WorkContainer) {
+            var workContainer = new WorkContainer(application.getDevice(), container, true);
             assertEquals(5, workContainer.getNumCharactersThatFit(LOREM_IPSUM, "..."));
             assertEquals(8, workContainer.getNumCharactersThatFit(LOREM_IPSUM, ""));
         });

--- a/static/script-tests/tests/widgets/label/texttruncation/workcontainer-test.js
+++ b/static/script-tests/tests/widgets/label/texttruncation/workcontainer-test.js
@@ -1,0 +1,87 @@
+
+(function() {
+    this.tests = AsyncTestCase("Work Container");
+
+    this.tests.prototype.setUp = function () {
+        this.sandbox = sinon.sandbox.create();
+        this.sourceText = "Donec dignissim lacus eu quam fringilla, vitae hendrerit tellus egestas. Aenean ultricies blandit tellus, ac vestibulum libero sagittis in. Integer purus tortor, placerat quis velit ac, pulvinar sodales augue. Maecenas sodales, arcu id aliquet consectetur, enim purus lacinia urna, nec sagittis sem elit a nunc. Nam sagittis molestie varius. Aliquam vehicula, nisi ut porta venenatis, diam ipsum sodales nisi, nec rhoncus lorem quam sit amet neque. Cras euismod porttitor felis, at pulvinar diam iaculis vel. Nullam tincidunt turpis sit amet nunc lacinia, a fermentum purus tincidunt. Curabitur ac elit a quam posuere fermentum in sit amet ante. Vivamus semper ligula non metus mattis, id feugiat mauris ultrices. Aliquam ullamcorper molestie metus eget laoreet. Sed gravida mi et mauris venenatis, nec ultricies lacus suscipit. Nullam placerat elit id euismod interdum. Proin et dui eget sem sodales bibendum. Nam pulvinar, libero id elementum sagittis, purus augue molestie dui, vel dapibus lorem nibh ac odio. In eu adipiscing sapien.";
+        this.parentContainer = setupParentContainer();
+    };
+
+    this.tests.prototype.tearDown = function () {
+        this.sandbox.restore();
+        destroyParentContainer(this.parentContainer);
+    };
+
+    function setupParentContainer() {
+        var container = document.createElement("div");
+        // try and set the css to that this will render the same in all browsers
+        container.style.display = "block";
+        container.style.margin = "0";
+        container.style.padding = "0";
+        container.style.borderStyle = "none";
+        container.style.fontFamily = "Courier, monospace";
+        container.style.fontStyle = "normal";
+        container.style.fontSize = "20px";
+        container.style.fontWeight = "normal";
+        document.body.appendChild(container);
+        return container;
+    }
+
+    function destroyParentContainer(container) {
+        document.body.removeChild(container);
+    }
+
+    this.tests.prototype.testCheckTextThatIsMoreThanContainersVerticalHeightWhenMeasuringVerticallyIsReportedAsOver = function (queue) {
+        expectAsserts(1);
+
+        queuedRequire(queue, ["antie/widgets/label/texttruncation/workcontainer"], function(WorkContainer) {
+            var container = document.createElement("div");
+            this.parentContainer.appendChild(container);
+            container.style.width = "100px";
+            container.style.height = "100px";
+            var workContainer = new WorkContainer(container, false);
+            assertEquals(true, workContainer.isOver(this.sourceText));
+        });
+    };
+
+    this.tests.prototype.testCheckTextThatIsLessThanContainersHeightWhenMeasuringVerticallyIsNotReportedAsOver = function (queue) {
+        expectAsserts(1);
+
+        queuedRequire(queue, ["antie/widgets/label/texttruncation/workcontainer"], function(WorkContainer) {
+            var container = document.createElement("div");
+            this.parentContainer.appendChild(container);
+            container.style.width = "100px";
+            container.style.height = "100px";
+            var workContainer = new WorkContainer(container, false);
+            assertEquals(false, workContainer.isOver("Two words."));
+        });
+    };
+
+    this.tests.prototype.testCheckTextThatIsMoreThanContainersWidthWhenMeasuringHorizontallyIsReportedAsOver = function (queue) {
+        expectAsserts(1);
+
+        queuedRequire(queue, ["antie/widgets/label/texttruncation/workcontainer"], function(WorkContainer) {
+            var container = document.createElement("div");
+            this.parentContainer.appendChild(container);
+            container.style.width = "100px";
+            container.style.height = "100px";
+            var workContainer = new WorkContainer(container, true);
+            assertEquals(true, workContainer.isOver(this.sourceText));
+        });
+    };
+
+    this.tests.prototype.testCheckTextThatIsLessThanContainersWidthWhenMeasuringHorizontallyIsNotReportedAsOver = function (queue) {
+        expectAsserts(1);
+
+        queuedRequire(queue, ["antie/widgets/label/texttruncation/workcontainer"], function(WorkContainer) {
+            var container = document.createElement("div");
+            this.parentContainer.appendChild(container);
+            container.style.width = "100px";
+            container.style.height = "100px";
+            var workContainer = new WorkContainer(container, true);
+            assertEquals(true, workContainer.isOver("Two words."));
+        });
+    };
+
+})();

--- a/static/script-tests/tests/widgets/label/texttruncation/workcontainer-test.js
+++ b/static/script-tests/tests/widgets/label/texttruncation/workcontainer-test.js
@@ -11,6 +11,8 @@
         this.sandbox = sinon.sandbox.create();
         this.parentContainer = setupParentContainer();
 
+
+
         container = document.createElement("div");
         this.parentContainer.appendChild(container);
         container.style.width = "100px";
@@ -94,6 +96,8 @@
 
         queuedRequire(queue, ["antie/widgets/label/texttruncation/workcontainer"], function(WorkContainer) {
             var workContainer = new WorkContainer(container, false);
+            //TODO
+            this.sandbox.stub(workContainer, "_create").returns({});
             assertEquals(30, workContainer.getNumCharactersThatFit(LOREM_IPSUM, "..."));
             assertEquals(33, workContainer.getNumCharactersThatFit(LOREM_IPSUM, ""));
         });

--- a/static/script-tests/tests/widgets/label/texttruncation/workcontainer-test.js
+++ b/static/script-tests/tests/widgets/label/texttruncation/workcontainer-test.js
@@ -28,17 +28,15 @@
     }
 
     function stubPositionGenerator(sandbox, PositionGenerator) {
-        (function() {
-            var positionGeneratorResults = [8, 4, 6];
-            sandbox.stub(PositionGenerator.prototype, "init", function () {
-            });
-            sandbox.stub(PositionGenerator.prototype, "hasNext", function () {
-                return positionGeneratorResults.length > 0;
-            });
-            sandbox.stub(PositionGenerator.prototype, "next", function () {
-                return positionGeneratorResults.shift();
-            });
-        })();
+        var positionGeneratorResults = [8, 4, 6];
+        sandbox.stub(PositionGenerator.prototype, "init", function () {
+        });
+        sandbox.stub(PositionGenerator.prototype, "hasNext", function () {
+            return positionGeneratorResults.length > 0;
+        });
+        sandbox.stub(PositionGenerator.prototype, "next", function () {
+            return positionGeneratorResults.shift();
+        });
     }
 
     function getMockDomContainer(w, h) {

--- a/static/script-tests/tests/widgets/label/texttruncation/workcontainer-test.js
+++ b/static/script-tests/tests/widgets/label/texttruncation/workcontainer-test.js
@@ -77,7 +77,7 @@
         });
     };
 
-    this.tests.prototype.testDestroyRemovesChildContainerFromParent = function (queue) {
+    this.tests.prototype.testCheckDestroyRemovesChildContainerFromParent = function (queue) {
         expectAsserts(3);
 
         queuedRequire(queue, ["antie/widgets/label/texttruncation/workcontainer"], function(WorkContainer) {
@@ -86,6 +86,26 @@
             assertEquals(1, container.childNodes.length);
             workContainer.destroy();
             assertEquals(0, container.childNodes.length);
+        });
+    };
+
+    this.tests.prototype.testCheckGetNumCharactersThatFitReturnsCorrectValuesWhenMeasuringVertically = function (queue) {
+        expectAsserts(2);
+
+        queuedRequire(queue, ["antie/widgets/label/texttruncation/workcontainer"], function(WorkContainer) {
+            var workContainer = new WorkContainer(container, false);
+            assertEquals(30, workContainer.getNumCharactersThatFit(LOREM_IPSUM, "..."));
+            assertEquals(33, workContainer.getNumCharactersThatFit(LOREM_IPSUM, ""));
+        });
+    };
+
+    this.tests.prototype.testCheckGetNumCharactersThatFitReturnsCorrectValuesWhenMeasuringHorizontally = function (queue) {
+        expectAsserts(2);
+
+        queuedRequire(queue, ["antie/widgets/label/texttruncation/workcontainer"], function(WorkContainer) {
+            var workContainer = new WorkContainer(container, true);
+            assertEquals(5, workContainer.getNumCharactersThatFit(LOREM_IPSUM, "..."));
+            assertEquals(8, workContainer.getNumCharactersThatFit(LOREM_IPSUM, ""));
         });
     };
 

--- a/static/script-tests/tests/widgets/label/texttruncation/workcontainer-test.js
+++ b/static/script-tests/tests/widgets/label/texttruncation/workcontainer-test.js
@@ -38,6 +38,8 @@
     function stubCssManager(sandbox, CssManager) {
         sandbox.stub(CssManager.prototype, "init");
         sandbox.stub(CssManager.prototype, "restore");
+        sandbox.stub(CssManager.prototype, "configureForMeasuring");
+        sandbox.stub(CssManager.prototype, "configureForAlgorithm");
     }
 
     function stubWorkContainer(sandbox, WorkContainer, sourceContainer) {

--- a/static/script-tests/tests/widgets/label/texttruncation/workcontainer-test.js
+++ b/static/script-tests/tests/widgets/label/texttruncation/workcontainer-test.js
@@ -117,7 +117,7 @@
             stubWorkContainer(this.sandbox, WorkContainer, mockContainer);
 
             var workContainer = new WorkContainer(application.getDevice(), getMockDomContainer(), false);
-            fakeSizeOfContainerThatIsCollapsingAroundContent(mockContainer, 100, 99);
+            fakeSizeOfContainerThatIsCollapsingAroundContent(mockContainer, 100, 100);
 
             assertEquals(false, workContainer.isOver(""));
         });

--- a/static/script/devices/anim/tween.js
+++ b/static/script/devices/anim/tween.js
@@ -27,11 +27,10 @@
 require.def(
     'antie/devices/anim/tween',
     [
-     'antie/devices/browserdevice',
-     'antie/lib/shifty',
-     'antie/widgets/widget'
-     ],
-     function(Device, Tweenable, Widget) {
+        'antie/devices/browserdevice',
+        'antie/lib/shifty'
+    ],
+    function(Device, Tweenable) {
         // A set of queues of DOM updates to perform. Each animation framerate gets its own queue
         // so they are in sync between themselves.
         var animQueues = {};
@@ -146,57 +145,45 @@ require.def(
             var anim = new Tweenable(options);
             var self = this;
 
-            // reference to the widget being animated (if widget supplied)
-            var widget = null;
-
-            if (options.el instanceof Widget) {
-                widget = options.el;
-                options.el = options.el.outputElement;
-            }
-
             var opts = {
-                    el: options.el,
-                    initialState: options.from || {},
-                    from: options.from || {},
-                    to: options.to || {},
-                    duration: options.duration || 840,
-                    easing: options.easing || 'easeFromTo',
-                    fps: options.fps || 25,
-                    start: function() {
-                        if (options.className) {
-                            self.removeClassFromElement(options.el, "not" + options.className);
-                            self.addClassToElement(options.el,  options.className);
-                        }
-                        self.removeClassFromElement(self.getTopLevelElement(), "notanimating");
-                        self.addClassToElement(self.getTopLevelElement(), "animating");
-                        if (options.onStart) {
-                            options.onStart();
-                        }
-                    },
-                    step: function () {
-                        addTweenToQueue(opts, this);
-                    },
-                    callback: function () {
-                        if(options.className) {
-                            self.removeClassFromElement(options.el, options.className);
-                            self.addClassToElement(options.el, "not" + options.className);
-                        }
-                        self.removeClassFromElement(self.getTopLevelElement(), "animating");
-                        self.addClassToElement(self.getTopLevelElement(), "notanimating");
-                        // Send this animation to its final state immediately.
-                        drainTweensFromQueue(opts);
-                        if (this) {
-                            step(opts, this);
-                        }
-                        // If the user supplied a Widget the call the render function
-                        if (widget) {
-                            widget.render();
-                        }
-                        // Fire client callback if it exists
-                        if (typeof options.onComplete === 'function') {
-                            options.onComplete();
-                        }
+                el: options.el,
+                initialState: options.from || {},
+                from: options.from || {},
+                to: options.to || {},
+                duration: options.duration || 840,
+                easing: options.easing || 'easeFromTo',
+                fps: options.fps || 25,
+                start: function() {
+                    if (options.className) {
+                        self.removeClassFromElement(options.el, "not" + options.className);
+                        self.addClassToElement(options.el,  options.className);
                     }
+                    self.removeClassFromElement(self.getTopLevelElement(), "notanimating");
+                    self.addClassToElement(self.getTopLevelElement(), "animating");
+                    if (options.onStart) {
+                        options.onStart();
+                    }
+                },
+                step: function () {
+                    addTweenToQueue(opts, this);
+                },
+                callback: function () {
+                    if(options.className) {
+                        self.removeClassFromElement(options.el, options.className);
+                        self.addClassToElement(options.el, "not" + options.className);
+                    }
+                    self.removeClassFromElement(self.getTopLevelElement(), "animating");
+                    self.addClassToElement(self.getTopLevelElement(), "notanimating");
+                    // Send this animation to its final state immediately.
+                    drainTweensFromQueue(opts);
+                    if (this) {
+                        step(opts, this);
+                    }
+                    // Fire client callback if it exists
+                    if (typeof options.onComplete === 'function') {
+                        options.onComplete();
+                    }
+                }
             };
 
             anim.tween(opts);

--- a/static/script/devices/anim/tween.js
+++ b/static/script/devices/anim/tween.js
@@ -28,9 +28,10 @@ require.def(
     'antie/devices/anim/tween',
     [
      'antie/devices/browserdevice',
-     'antie/lib/shifty'
+     'antie/lib/shifty',
+     'antie/widgets/widget'
      ],
-     function(Device, Tweenable) {
+     function(Device, Tweenable, Widget) {
         // A set of queues of DOM updates to perform. Each animation framerate gets its own queue
         // so they are in sync between themselves.
         var animQueues = {};
@@ -145,6 +146,14 @@ require.def(
             var anim = new Tweenable(options);
             var self = this;
 
+            // reference to the widget being animated (if widget supplied)
+            var widget = null;
+
+            if (options.el instanceof Widget) {
+                widget = options.el;
+                options.el = options.el.outputElement;
+            }
+
             var opts = {
                     el: options.el,
                     initialState: options.from || {},
@@ -178,6 +187,10 @@ require.def(
                         drainTweensFromQueue(opts);
                         if (this) {
                             step(opts, this);
+                        }
+                        // If the user supplied a Widget the call the render function
+                        if (widget) {
+                            Widget.render();
                         }
                         // Fire client callback if it exists
                         if (typeof options.onComplete === 'function') {

--- a/static/script/devices/anim/tween.js
+++ b/static/script/devices/anim/tween.js
@@ -190,7 +190,7 @@ require.def(
                         }
                         // If the user supplied a Widget the call the render function
                         if (widget) {
-                            Widget.render();
+                            widget.render();
                         }
                         // Fire client callback if it exists
                         if (typeof options.onComplete === 'function') {

--- a/static/script/devices/browserdevice.js
+++ b/static/script/devices/browserdevice.js
@@ -51,7 +51,6 @@ require.def("antie/devices/browserdevice",
              */
             init: function(config) {
                 this._super(config);
-                this._textSizeCache = {};
 
                 this.addClassToElement(this.getTopLevelElement(), "notanimating");
             },
@@ -442,39 +441,6 @@ require.def("antie/devices/browserdevice",
                 return clone;
             },
             /**
-             * Get the height (in pixels) of a given block of text (of a provided set of class names) when constrained to a fixed width.
-             *
-             * @deprecated This function does not always give accurate results. When measuring size, it only takes into account
-             * the classes on the text element being measured. It doesn't consider any CSS styles that may have been passed down
-             * through the DOM.
-             *
-             * @param {String} text The text to measure.
-             * @param {Integer} maxWidth The width the text is constrained to.
-             * @param {Array} classNames An array of class names which define the style of the text.
-             * @returns The height (in pixels) that is required to display this block of text.
-             */
-            getTextHeight: function(text, maxWidth, classNames) {
-                /// TODO: is there a more efficient way of doing this?
-                var cacheKey = maxWidth + ":" + classNames.join(" ") + ":" + text;
-                var height;
-                if (!(height = this._textSizeCache[cacheKey])) {
-                    if (!this._measureTextElement) {
-                        this._measureTextElement = this.createLabel("measure", null, "fW");
-                        this._measureTextElement.style.display = "block";
-                        this._measureTextElement.style.position = "absolute";
-                        this._measureTextElement.style.top = "-10000px";
-                        this._measureTextElement.style.left = "-10000px";
-                        this.appendChildElement(document.body, this._measureTextElement);
-                    }
-                    this._measureTextElement.className = classNames.join(" ");
-                    this._measureTextElement.style.width = (typeof maxWidth === 'number') ? maxWidth + "px" : maxWidth;
-                    this._measureTextElement.innerHTML = text;
-
-                    height = this._textSizeCache[cacheKey] = this._measureTextElement.clientHeight;
-                }
-                return height;
-            },
-            /**
              * Returns all direct children of an element which have the provided tagName.
              * @param {Element} el The element who's children you wish to search.
              * @param {String} tagName The tag name you are looking for.
@@ -602,7 +568,6 @@ require.def("antie/devices/browserdevice",
             getWindowLocation: function() {
                 var windowLocation, copyProps, prop, i, newLocation;
                 windowLocation = this._windowLocation || window.location; // Allow stubbing for unit testing
-
                 // Has the device missed the route off the href? Fix this.
                 if (windowLocation.hash && windowLocation.hash.length > 1 && windowLocation.href && windowLocation.href.lastIndexOf('#') === -1) {
                     // Copy properties to new object, as modifying href on the original window.location triggers a navigation.

--- a/static/script/devices/browserdevice.js
+++ b/static/script/devices/browserdevice.js
@@ -479,7 +479,7 @@ require.def("antie/devices/browserdevice",
              * @returns The height (in pixels) that is required to display this block of text.
              */
             getTextHeight: function(text, maxWidth, classNames) {
-                /// TODO: is there a more efficient way of doing this?
+                /// TODO: Revert this back to the original!
                 var cacheKey = maxWidth + ":" + classNames.join(" ") + ":" + text;
                 var height;
                 if (!(height = this._textSizeCache[cacheKey])) {

--- a/static/script/devices/browserdevice.js
+++ b/static/script/devices/browserdevice.js
@@ -52,7 +52,6 @@ require.def("antie/devices/browserdevice",
             init: function(config) {
                 this._super(config);
                 this._textSizeCache = {};
-                this._addedToVisibleDomCallbackEls = [];
 
                 this.addClassToElement(this.getTopLevelElement(), "notanimating");
             },
@@ -235,31 +234,7 @@ require.def("antie/devices/browserdevice",
              * @param {Element} el The new child element.
              */
             appendChildElement: function(to, el) {
-
-                // TODO: this could probably be done a lot nicer. Maybe with an extra event like WidgetAddedToVisibleDomEvent ?
-                if (typeof el.onAddedToVisibleDom == "function" && !el.onAddedToVisibleDomRegistered) {
-                    this._addedToVisibleDomCallbackEls.push(el);
-                    el.onAddedToVisibleDomRegistered = true;
-                }
-
                 to.appendChild(el);
-
-                // if this element is being appended to the visible dom, then go throgh and call call all the callbacks for this and anything below it which is now also on the visible dom.
-                if (document.contains(el)) {
-                    var toDelete = [];
-                    for(var i=0; i<this._addedToVisibleDomCallbackEls.length; i++) {
-                        if (document.contains(this._addedToVisibleDomCallbackEls[i])) {
-                            (function(callback) {
-                                setTimeout(callback, 0);
-                            })(this._addedToVisibleDomCallbackEls[i].onAddedToVisibleDom);
-                            toDelete.push(i);
-                        }
-                    }
-                    toDelete = toDelete.reverse();
-                    for(var i=0; i<toDelete.length; i++) {
-                        this._addedToVisibleDomCallbackEls.splice(toDelete[i], 1);
-                    }
-                }
             },
             /**
              * Prepends an element as a child of another.
@@ -479,7 +454,7 @@ require.def("antie/devices/browserdevice",
              * @returns The height (in pixels) that is required to display this block of text.
              */
             getTextHeight: function(text, maxWidth, classNames) {
-                /// TODO: Revert this back to the original!
+                /// TODO: is there a more efficient way of doing this?
                 var cacheKey = maxWidth + ":" + classNames.join(" ") + ":" + text;
                 var height;
                 if (!(height = this._textSizeCache[cacheKey])) {
@@ -511,7 +486,7 @@ require.def("antie/devices/browserdevice",
                 for (var i = 0; i < el.childNodes.length; i++) {
                     if(el.childNodes[i].tagName){
                         if (el.childNodes[i].tagName.toLowerCase() == tagName) {
-                        children.push(el.childNodes[i]);
+                            children.push(el.childNodes[i]);
                         }
                     }
                 }
@@ -560,10 +535,10 @@ require.def("antie/devices/browserdevice",
 //                        left: rect.left - parentRect.left
 //                    };
 //                } else {
-                    offsets = {
-                        top: el.offsetTop,
-                        left: el.offsetLeft
-                    };
+                offsets = {
+                    top: el.offsetTop,
+                    left: el.offsetLeft
+                };
 //                }
                 return offsets;
             },
@@ -592,7 +567,7 @@ require.def("antie/devices/browserdevice",
              */
             setCurrentRoute: function(route) {
                 var history = this.getHistorian().toString();
-                
+
                 if (route.length > 0) {
                     window.location.hash = "#" + route.join("/") + history;
                 } else {
@@ -607,7 +582,7 @@ require.def("antie/devices/browserdevice",
                 var unescaped = unescape(window.location.hash).split(Historian.HISTORY_TOKEN, 1)[0];
                 return (unescaped.replace(/^#/, '').split('/'));
             },
-            
+
             /**
              * gets historian for current location
              * @returns {antie.Historian} an object that can be used to get a back or forward url between applications while preserving history
@@ -615,7 +590,7 @@ require.def("antie/devices/browserdevice",
             getHistorian: function() {
                 return new Historian(decodeURI(this.getWindowLocation().href));
             },
-            
+
             /**
              * Get an object giving access to the current URL, query string, hash etc.
              * @returns {Object} Object containing, at a minimum, the properties:

--- a/static/script/widgets/label.js
+++ b/static/script/widgets/label.js
@@ -67,7 +67,7 @@ require.def('antie/widgets/label',
              */
             render: function(device) {
 
-                var alreadyAddedToDom = !!this.outputElement;
+                var alreadyAddedToDom = !!this.outputElement && document.contains(this.outputElement);
                 if (!this.outputElement) {
                     this.outputElement = device.createLabel(this.id, this.getClasses(), "");
                 }
@@ -81,6 +81,7 @@ require.def('antie/widgets/label',
                     }
                     else {
                         var doTruncation = function () {
+                            console.log("TRUNCATING");
                             device.setElementContent(self.outputElement, self._truncateText());
                         };
                         // the element needs to already be on the dom for the truncation to work and this happens after the

--- a/static/script/widgets/label.js
+++ b/static/script/widgets/label.js
@@ -104,7 +104,7 @@ require.def('antie/widgets/label',
                         for (var currentLine = 0; currentLine < numLoopIterations; currentLine++) {
 
                             var remainingTxt = txt.slice(currentLineStartIndex, txt.length);
-                            var numCharsThatFit = TruncationHelpers.getNumCharactersThatFit(workContainer, remainingTxt, noLines === 0 || currentLine === noLines - 1 ? txtEnd : "", noLines !== 0);
+                            var numCharsThatFit = workContainer.getNumCharactersThatFit(remainingTxt, noLines === 0 || currentLine === noLines - 1 ? txtEnd : "", noLines !== 0);
                             truncationHappened = numCharsThatFit !== remainingTxt.length;
                             remainingTxt = remainingTxt.slice(0, numCharsThatFit);
 

--- a/static/script/widgets/label.js
+++ b/static/script/widgets/label.js
@@ -66,7 +66,7 @@ require.def('antie/widgets/label',
 			 */
 			render: function(device) {
 
-                var alreadyAddedToDom = this.outputElement;
+                var alreadyAddedToDom = !!this.outputElement;
                 if (!this.outputElement) {
                     this.outputElement = device.createLabel(this.id, this.getClasses(), "");
                 }

--- a/static/script/widgets/label.js
+++ b/static/script/widgets/label.js
@@ -57,10 +57,7 @@ require.def('antie/widgets/label',
                 this._maxLines = null;
                 this._ellipsisText = "...";
                 this._splitAtWordBoundary = true;
-                // TODO: set to false
-                this._useCssForTruncationIfAvailable = true;
-                var config = this.getCurrentApplication().getDevice().getConfig();
-                this._deviceSupportsCssTruncation = config.css.supportsTextTruncation;
+                this._useCssForTruncationIfAvailable = false;
                 this.addClass('label');
             },
             /**
@@ -78,7 +75,7 @@ require.def('antie/widgets/label',
                 if (this._truncationMode == Label.TRUNCATION_MODE_RIGHT_ELLIPSIS) {
                     var self = this;
 
-                    if (this._shouldUseCssForTruncation()) {
+                    if (this._shouldUseCssForTruncation(device)) {
                         this._setCssForTruncation();
                         device.setElementContent(this.outputElement, this._text);
                     }
@@ -110,7 +107,7 @@ require.def('antie/widgets/label',
             },
             // returns true if the current truncation settings are achievable with css and the user has asked for this.
             // throws an exception if the current truncation settings are not achievable with css and the user asked for css to be used.
-            _shouldUseCssForTruncation: function() {
+            _shouldUseCssForTruncation: function(device) {
                 if (!this._useCssForTruncationIfAvailable) {
                     return false;
                 }
@@ -118,7 +115,7 @@ require.def('antie/widgets/label',
                     this.getCurrentApplication().getDevice().getLogger().error("You chose to use css for truncation but this is not possible without specifying the number of lines you would like. If you want the text to fill the container you cannot use the css method.");
                     return false;
                 }
-                return this._deviceSupportsCssTruncation;
+                return device.getConfig().css.supportsTextTruncation;
             },
             _setCssForTruncation: function() {
                 this.outputElement.style.overflow = "hidden";

--- a/static/script/widgets/label.js
+++ b/static/script/widgets/label.js
@@ -72,30 +72,37 @@ require.def('antie/widgets/label',
                 }
 
 				if (this._truncationMode == Label.TRUNCATION_MODE_RIGHT_ELLIPSIS) {
-                    var self = this;
-                    var doTruncation = function() {
-                        device.setElementContent(self.outputElement, self._truncateText());
-                    };
-                    // the element needs to already be on the dom for the truncation to work and this happens after the
-                    // first render. So if this is the first render, ie this label is not in the dom yet, wait until this
-                    // has happened by using a setTimeout with delay of 0. Otherwise do the truncation immediately.
-                    if (alreadyAddedToDom) {
-                        doTruncation()
-                    }
-                    else {
-                        setTimeout(doTruncation, 0);
-                    }
+                    this.doTruncation(device, alreadyAddedToDom);
 				}
                 else {
                     device.setElementContent(this.outputElement, this._text);
 				}
 				return this.outputElement;
 			},
-            _truncateText: function() {
-                var truncator = new Truncator(this.getCurrentApplication().getDevice());
-                truncator.setSplitAtWordBoundary(this._splitAtWordBoundary);
-                truncator.setEllipsisText(this._ellipsisText);
-                return truncator.truncateText(this.outputElement, this._text, this._maxLines);
+            /**
+             * Performs text truncation on the output element.
+             * This is set with a modifier.
+             * @param {antie.devices.Device} device The device that's being rendered to.
+             * @param {boolean} alreadyAddedToDom Whether or not the output element is already on the dom
+             */
+            doTruncation: function(device, alreadyAddedToDom) {
+                var self = this;
+                var callback = function() {
+                    var truncator = new Truncator(self.getCurrentApplication().getDevice());
+                    truncator.setSplitAtWordBoundary(self._splitAtWordBoundary);
+                    truncator.setEllipsisText(self._ellipsisText);
+                    var truncatedText = truncator.truncateText(self.outputElement, self._text, self._maxLines);
+                    device.setElementContent(self.outputElement, truncatedText);
+                };
+                // the element needs to already be on the dom for the truncation to work and this happens after the
+                // first render. So if this is the first render, ie this label is not in the dom yet, wait until this
+                // has happened by using a setTimeout with delay of 0. Otherwise do the truncation immediately.
+                if (alreadyAddedToDom) {
+                    callback()
+                }
+                else {
+                    setTimeout(callback, 0);
+                }
             },
 			/**
 			 * Sets the text displayed by this label.

--- a/static/script/widgets/label.js
+++ b/static/script/widgets/label.js
@@ -55,8 +55,8 @@ require.def('antie/widgets/label',
 				}
 				this._truncationMode = Label.TRUNCATION_MODE_NONE;
 				this._maxLines = null;
-                this._ellipsisText = "null";
-                this._splitAtWordBoundary = false;
+                this._ellipsisText = "...";
+                this._splitAtWordBoundary = true;
 				this.addClass('label');
 			},
 			/**
@@ -133,8 +133,9 @@ require.def('antie/widgets/label',
                 this._ellipsisText = ellipsisText;
             },
             /**
-             * TODO
-             * @param {Boolean} Whether to allow truncating text part way through a word or not.
+             * Set whether or not to allow truncating text part way through a word.
+             * @param {Boolean} True means the truncated text will always end on a complete word. False means it may
+             *                  occur after any character.
              */
             setSplitAtWordBoundary: function(splitAtWordBoundary) {
                 this._splitAtWordBoundary = splitAtWordBoundary;
@@ -146,7 +147,7 @@ require.def('antie/widgets/label',
              * @param {Integer} width The width of this label in pixels
              */
             setWidth: function(width) {
-                // TODO: throw deprecated msg
+                throw "setWidth() called on Label but this method is now deprecated and has no effect.";
             }
 		});
 

--- a/static/script/widgets/label.js
+++ b/static/script/widgets/label.js
@@ -81,7 +81,6 @@ require.def('antie/widgets/label',
                     }
                     else {
                         var doTruncation = function () {
-                            console.log("TRUNCATING");
                             device.setElementContent(self.outputElement, self._truncateText());
                         };
                         // the element needs to already be on the dom for the truncation to work and this happens after the

--- a/static/script/widgets/label.js
+++ b/static/script/widgets/label.js
@@ -96,7 +96,6 @@ require.def('antie/widgets/label',
                         // the index of the text where the current line starts
                         var currentLineStartIndex = 0;
 
-
                         // the loop will run for each line. If this is run with noLines as 0 this means fit the height of the label.
                         // in this case the loop should only run once as it's the height that's being measured.
                         var numLoopIterations = noLines === 0 ? 1 : noLines;

--- a/static/script/widgets/label.js
+++ b/static/script/widgets/label.js
@@ -77,6 +77,9 @@ require.def('antie/widgets/label',
                         // if set to false then the text may be cut off midway through a word.
                         var cutOffWord = true;
 
+                        // clear any text that's currently there
+                        outputElement.innerHTML = "";
+
                         // put the text node that we will be working on inside a container in the target el.
                         // the container will be set to fill the main element
                         // this means we can set the visibility to hidden and overflow to hidden on this container to make sure any temporary work isn't visible and doesn't effect anything else on the page.

--- a/static/script/widgets/label.js
+++ b/static/script/widgets/label.js
@@ -28,10 +28,9 @@ require.def('antie/widgets/label',
 	[
         'antie/widgets/widget',
         'antie/widgets/label/texttruncation/workcontainer',
-        'antie/widgets/label/texttruncation/cssmanager',
         'antie/widgets/label/texttruncation/helpers'
     ],
-	function(Widget, WorkContainer, CssManager, TruncationHelpers) {
+	function(Widget, WorkContainer, TruncationHelpers) {
 		/**
 		 * The Label widget displays text. It supports auto-truncation (with ellipsis) of text to fit.
 		 * @name antie.widgets.Label
@@ -91,7 +90,6 @@ require.def('antie/widgets/label',
                         el.innerHTML = "";
 
                         var workContainer = new WorkContainer(el, noLines !== 0);
-                        var cssManager = new CssManager(el, noLines !== 0);
 
                         // to contain the final text
                         var finalTxt = "";
@@ -143,8 +141,6 @@ require.def('antie/widgets/label',
                         }
 
                         workContainer.destroy();
-                        // set css properties that have been modified back to their original values
-                        cssManager.restore();
                         device.setElementContent(self.outputElement, finalTxt);
                     };
 

--- a/static/script/widgets/label.js
+++ b/static/script/widgets/label.js
@@ -114,7 +114,8 @@ require.def('antie/widgets/label',
                 if (this._maxLines === null) {
                     throw new Error("You chose to use css for truncation but this is not possible without specifying the number of lines you would like. If you want the text to fill the container you cannot use the css method.");
                 }
-                return device.getConfig().css.supportsTextTruncation;
+                var config = device.getConfig();
+                return config.hasOwnProperty("css") && config.css.hasOwnProperty("supportsTextTruncation") && config.css.supportsTextTruncation;
             },
             _setCssForTruncation: function() {
                 this.outputElement.style.overflow = "hidden";

--- a/static/script/widgets/label.js
+++ b/static/script/widgets/label.js
@@ -66,19 +66,24 @@ require.def('antie/widgets/label',
 			 */
 			render: function(device) {
 
+                var alreadyAddedToDom = this.outputElement;
                 if (!this.outputElement) {
                     this.outputElement = device.createLabel(this.id, this.getClasses(), "");
                 }
 
 				if (this._truncationMode == Label.TRUNCATION_MODE_RIGHT_ELLIPSIS) {
                     var self = this;
-                    setTimeout(function() {
+                    var doTruncation = function() {
                         device.setElementContent(self.outputElement, self._truncateText());
-                    }, 0);
-				} else {
+                    };
+                    // the element needs to already be on the dom for the truncation to work and this happens after the
+                    // first render. So if this is the first render, ie this label is not in the dom yet, wait until this
+                    // has happened by using a setTimeout with delay of 0. Otherwise do the truncation immediately.
+                    alreadyAddedToDom ? doTruncation() : setTimeout(doTruncation, 0);
+				}
+                else {
                     device.setElementContent(this.outputElement, this._text);
 				}
-
 				return this.outputElement;
 			},
             _truncateText: function() {

--- a/static/script/widgets/label.js
+++ b/static/script/widgets/label.js
@@ -82,7 +82,7 @@ require.def('antie/widgets/label',
 				return this.outputElement;
 			},
             _truncateText: function() {
-                var truncator = new Truncator();
+                var truncator = new Truncator(this.getCurrentApplication().getDevice());
                 truncator.setSplitAtWordBoundary(this._splitAtWordBoundary);
                 truncator.setEllipsisText(this._ellipsisText);
                 return truncator.truncateText(this.outputElement, this._text, this._maxLines);

--- a/static/script/widgets/label.js
+++ b/static/script/widgets/label.js
@@ -112,7 +112,7 @@ require.def('antie/widgets/label',
                     return false;
                 }
                 if (this._maxLines === null) {
-                    throw "You chose to use css for truncation but this is not possible without specifying the number of lines you would like. If you want the text to fill the container you cannot use the css method.";
+                    throw new Error("You chose to use css for truncation but this is not possible without specifying the number of lines you would like. If you want the text to fill the container you cannot use the css method.");
                 }
                 return device.getConfig().css.supportsTextTruncation;
             },
@@ -156,7 +156,7 @@ require.def('antie/widgets/label',
              */
             setMaximumLines: function(numberLines) {
                 if (numberLines !== null && numberLines <= 0) {
-                    throw "The number of lines must be 1 or more, or null.";
+                    throw new Error("The number of lines must be 1 or more, or null.");
                 }
                 this._maxLines = numberLines;
             },
@@ -193,7 +193,7 @@ require.def('antie/widgets/label',
              * @param {Integer} width The width of this label in pixels
              */
             setWidth: function(width) {
-                throw "setWidth() called on Label but this method is now deprecated and has no effect.";
+                throw new Error("setWidth() called on Label but this method is now deprecated and has no effect.");
             }
         });
 

--- a/static/script/widgets/label.js
+++ b/static/script/widgets/label.js
@@ -76,7 +76,9 @@ require.def('antie/widgets/label',
 
                     var self = this;
 
+                    // TODO: Check if this is a TAL supported mechanism for checking when the element has been added to the DOM
                     this.outputElement.onAddedToVisibleDom = function() {
+                        // TODO? Extract this to a truncator(?) class that is instantiated when required
                         var el = self.outputElement;
                         var noLines = self._maxLines;
                         var txt = self._text;

--- a/static/script/widgets/label.js
+++ b/static/script/widgets/label.js
@@ -111,9 +111,8 @@ require.def('antie/widgets/label',
                 if (!this._useCssForTruncationIfAvailable) {
                     return false;
                 }
-                if (this._maxLines === 0) {
-                    this.getCurrentApplication().getDevice().getLogger().error("You chose to use css for truncation but this is not possible without specifying the number of lines you would like. If you want the text to fill the container you cannot use the css method.");
-                    return false;
+                if (this._maxLines === null) {
+                    throw "You chose to use css for truncation but this is not possible without specifying the number of lines you would like. If you want the text to fill the container you cannot use the css method.";
                 }
                 return device.getConfig().css.supportsTextTruncation;
             },
@@ -156,6 +155,9 @@ require.def('antie/widgets/label',
              * @param {number} lines The maximum number of lines to display.
              */
             setMaximumLines: function(numberLines) {
+                if (numberLines !== null && numberLines <= 0) {
+                    throw "The number of lines must be 1 or more, or null.";
+                }
                 this._maxLines = numberLines;
             },
             /**

--- a/static/script/widgets/label.js
+++ b/static/script/widgets/label.js
@@ -27,9 +27,8 @@
 require.def('antie/widgets/label',
 	[
         'antie/widgets/widget',
-        'antie/widgets/label/texttruncation/truncator'
     ],
-	function(Widget, Truncator) {
+	function(Widget) {
 		/**
 		 * The Label widget displays text. It supports auto-truncation (with ellipsis) of text to fit.
 		 * @name antie.widgets.Label
@@ -86,23 +85,7 @@ require.def('antie/widgets/label',
              * @param {boolean} alreadyAddedToDom Whether or not the output element is already on the dom
              */
             doTruncation: function(device, alreadyAddedToDom) {
-                var self = this;
-                var callback = function() {
-                    var truncator = new Truncator(self.getCurrentApplication().getDevice());
-                    truncator.setSplitAtWordBoundary(self._splitAtWordBoundary);
-                    truncator.setEllipsisText(self._ellipsisText);
-                    var truncatedText = truncator.truncateText(self.outputElement, self._text, self._maxLines);
-                    device.setElementContent(self.outputElement, truncatedText);
-                };
-                // the element needs to already be on the dom for the truncation to work and this happens after the
-                // first render. So if this is the first render, ie this label is not in the dom yet, wait until this
-                // has happened by using a setTimeout with delay of 0. Otherwise do the truncation immediately.
-                if (alreadyAddedToDom) {
-                    callback()
-                }
-                else {
-                    setTimeout(callback, 0);
-                }
+                throw "doTruncation() was called on Label but has not been overridden by a modifier.";
             },
 			/**
 			 * Sets the text displayed by this label.

--- a/static/script/widgets/label.js
+++ b/static/script/widgets/label.js
@@ -114,6 +114,9 @@ require.def('antie/widgets/label',
                 if (this._maxLines === null) {
                     throw new Error("You chose to use css for truncation but this is not possible without specifying the number of lines you would like. If you want the text to fill the container you cannot use the css method.");
                 }
+                if (this._splitAtWordBoundary) {
+                    throw new Error("You chose to use css for truncation but also truncate at a word boundary. This is not possible with the css method.");
+                }
                 var config = device.getConfig();
                 return config.hasOwnProperty("css") && config.css.hasOwnProperty("supportsTextTruncation") && config.css.supportsTextTruncation;
             },
@@ -169,7 +172,8 @@ require.def('antie/widgets/label',
                 this._ellipsisText = ellipsisText;
             },
             /**
-             * Set whether or not to allow truncating text part way through a word.
+             * Set whether or not to allow truncating text part way through a word. Defaults to true.
+             * This must be false when using the css method as css doesn't support truncating at a word boundary.
              * @param {Boolean} splitAtWordBoundary True means the truncated text will always end on a complete word. False means it may
              *                                      occur after any character.
              */

--- a/static/script/widgets/label.js
+++ b/static/script/widgets/label.js
@@ -19,107 +19,117 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * 
+ *
  * All rights reserved
  * Please contact us for an alternative licence
  */
 
 require.def('antie/widgets/label',
-	[
+    [
         'antie/widgets/widget',
+        'antie/widgets/label/texttruncation/truncator'
     ],
-	function(Widget) {
-		/**
-		 * The Label widget displays text. It supports auto-truncation (with ellipsis) of text to fit.
-		 * @name antie.widgets.Label
-		 * @class
-		 * @extends antie.widgets.Widget
-		 * @param {String} [id] The unique ID of the widget. If excluded, a temporary internal ID will be used (but not included in any output).
-		 * @param {String} [text] The text content of this label.
-		 */
-		var Label = Widget.extend(/** @lends antie.widgets.Label.prototype */ {
-			/**
-			 * @constructor
-			 * @ignore
-			 */
-			init: function(id, text) {
+    function(Widget, Truncator) {
+        /**
+         * The Label widget displays text. It supports auto-truncation (with ellipsis) of text to fit.
+         * @name antie.widgets.Label
+         * @class
+         * @extends antie.widgets.Widget
+         * @param {String} [id] The unique ID of the widget. If excluded, a temporary internal ID will be used (but not included in any output).
+         * @param {String} [text] The text content of this label.
+         */
+        var Label = Widget.extend(/** @lends antie.widgets.Label.prototype */ {
+            /**
+             * @constructor
+             * @ignore
+             */
+            init: function(id, text) {
                 // The current API states that if only one parameter is passed to
                 // use that value as the text and auto generate an internal id
-				if(arguments.length == 1) {
-					this._text = id;
-					this._super();
-				} else {
-					this._text = text;
-					this._super(id);
-				}
-				this._truncationMode = Label.TRUNCATION_MODE_NONE;
-				this._maxLines = null;
+                if(arguments.length == 1) {
+                    this._text = id;
+                    this._super();
+                } else {
+                    this._text = text;
+                    this._super(id);
+                }
+                this._truncationMode = Label.TRUNCATION_MODE_NONE;
+                this._maxLines = null;
                 this._ellipsisText = "...";
                 this._splitAtWordBoundary = true;
-				this.addClass('label');
-			},
-			/**
-			 * Renders the widget and any child widgets to device-specific output.
-			 * @param {antie.devices.Device} device The device to render to.
-			 * @returns A device-specific object that represents the widget as displayed on the device (in a browser, a DOMElement);
-			 */
-			render: function(device) {
+                this.addClass('label');
+            },
+            /**
+             * Renders the widget and any child widgets to device-specific output.
+             * @param {antie.devices.Device} device The device to render to.
+             * @returns A device-specific object that represents the widget as displayed on the device (in a browser, a DOMElement);
+             */
+            render: function(device) {
 
                 var alreadyAddedToDom = !!this.outputElement;
                 if (!this.outputElement) {
                     this.outputElement = device.createLabel(this.id, this.getClasses(), "");
                 }
 
-				if (this._truncationMode == Label.TRUNCATION_MODE_RIGHT_ELLIPSIS) {
-                    this.doTruncation(device, alreadyAddedToDom);
-				}
+                if (this._truncationMode == Label.TRUNCATION_MODE_RIGHT_ELLIPSIS) {
+                    var self = this;
+                    var doTruncation = function() {
+                        device.setElementContent(self.outputElement, self._truncateText());
+                    };
+                    // the element needs to already be on the dom for the truncation to work and this happens after the
+                    // first render. So if this is the first render, ie this label is not in the dom yet, wait until this
+                    // has happened by using a setTimeout with delay of 0. Otherwise do the truncation immediately.
+                    if (alreadyAddedToDom) {
+                        doTruncation()
+                    }
+                    else {
+                        setTimeout(doTruncation, 0);
+                    }
+                }
                 else {
                     device.setElementContent(this.outputElement, this._text);
-				}
-				return this.outputElement;
-			},
-            /**
-             * Performs text truncation on the output element.
-             * This is set with a modifier.
-             * @param {antie.devices.Device} device The device that's being rendered to.
-             * @param {boolean} alreadyAddedToDom Whether or not the output element is already on the dom
-             */
-            doTruncation: function(device, alreadyAddedToDom) {
-                throw "doTruncation() was called on Label but has not been overridden by a modifier.";
+                }
+                return this.outputElement;
             },
-			/**
-			 * Sets the text displayed by this label.
-			 * @param {String} text The new text to be displayed.
-			 */
-			setText: function(text) {
-				this._text = text;
-				if(this.outputElement) {
-					this.render(this.getCurrentApplication().getDevice());
-				}
-			},
-			/**
-			 * Gets the current text displayed by this label.
-			 * @returns The current text displayed by this label.
-			 */
-			getText: function() {
-				return this._text;
-			},
-			/**
-			 * Sets the truncation mode (currently {@link antie.widgets.Label.TRUNCATION_MODE_NONE} or {@link antie.widgets.Label.TRUNCATION_MODE_RIGHT_ELLIPSIS}).
-			 *
-			 * @param {String} mode The new truncation mode.
-			 */
-			setTruncationMode: function(mode) {
-				this._truncationMode = mode;
-			},
-			/**
-			 * Sets the maximum lines displayed when a truncation mode is set.
+            _truncateText: function() {
+                var truncator = new Truncator(this.getCurrentApplication().getDevice());
+                truncator.setSplitAtWordBoundary(this._splitAtWordBoundary);
+                truncator.setEllipsisText(this._ellipsisText);
+                return truncator.truncateText(this.outputElement, this._text, this._maxLines);
+            },
+            /**
+             * Sets the text displayed by this label.
+             * @param {String} text The new text to be displayed.
+             */
+            setText: function(text) {
+                this._text = text;
+                if(this.outputElement) {
+                    this.render(this.getCurrentApplication().getDevice());
+                }
+            },
+            /**
+             * Gets the current text displayed by this label.
+             * @returns The current text displayed by this label.
+             */
+            getText: function() {
+                return this._text;
+            },
+            /**
+             * Sets the truncation mode (currently {@link antie.widgets.Label.TRUNCATION_MODE_NONE} or {@link antie.widgets.Label.TRUNCATION_MODE_RIGHT_ELLIPSIS}).
+             *
+             * @param {String} mode The new truncation mode.
+             */
+            setTruncationMode: function(mode) {
+                this._truncationMode = mode;
+            },
+            /**
+             * Sets the maximum lines displayed when a truncation mode is set.
              * This is optional and if not specified the text will just be truncated when it no longer fits the box.
-			 * @param {String} lines The maximum number of lines to display.
-			 */
-			setMaximumLines: function(numberLines) {
-				this._maxLines = numberLines;
-			},
+             * @param {String} lines The maximum number of lines to display.
+             */
+            setMaximumLines: function(numberLines) {
+                this._maxLines = numberLines;
+            },
             /**
              * Sets the text to append at the end of the truncated text. Defaults to "..."
              * @param {String} lines The text to append.
@@ -144,25 +154,25 @@ require.def('antie/widgets/label',
             setWidth: function(width) {
                 throw "setWidth() called on Label but this method is now deprecated and has no effect.";
             }
-		});
+        });
 
-		/**
-		 * Do not truncate the text. Let the browser wrap to as many lines required to display all the text.
-		 * @name TRUNCATION_MODE_NONE
-		 * @memberOf antie.widgets.Label
-		 * @constant
-		 * @static
-		 */
-		Label.TRUNCATION_MODE_NONE = 0;
-		/**
-		 * Truncate text to fit into the number of lines specified by {@link antie.widgets.Label#setMaximumLines} by removing characters at the end of the string and append an ellipsis if text is truncated.
-		 * @constant
-		 * @name TRUNCATION_MODE_RIGHT_ELLIPSIS
-		 * @memberOf antie.widgets.Label
-		 * @static
-		 */
-		Label.TRUNCATION_MODE_RIGHT_ELLIPSIS = 1;
+        /**
+         * Do not truncate the text. Let the browser wrap to as many lines required to display all the text.
+         * @name TRUNCATION_MODE_NONE
+         * @memberOf antie.widgets.Label
+         * @constant
+         * @static
+         */
+        Label.TRUNCATION_MODE_NONE = 0;
+        /**
+         * Truncate text to fit into the number of lines specified by {@link antie.widgets.Label#setMaximumLines} by removing characters at the end of the string and append an ellipsis if text is truncated.
+         * @constant
+         * @name TRUNCATION_MODE_RIGHT_ELLIPSIS
+         * @memberOf antie.widgets.Label
+         * @static
+         */
+        Label.TRUNCATION_MODE_RIGHT_ELLIPSIS = 1;
 
-		return Label;
-	}
+        return Label;
+    }
 );

--- a/static/script/widgets/label.js
+++ b/static/script/widgets/label.js
@@ -57,6 +57,8 @@ require.def('antie/widgets/label',
 				}
 				this._truncationMode = Label.TRUNCATION_MODE_NONE;
 				this._maxLines = 0;
+                this._truncationEndText = "...";
+                this._allowTruncationPartThroughWord = false;
 				this.addClass('label');
 			},
 			/**
@@ -79,9 +81,9 @@ require.def('antie/widgets/label',
                         var noLines = self._maxLines;
                         var txt = self._text;
                         // if set to false then the text may be cut off midway through a word.
-                        var cutOffWord = true;
+                        var cutOffWord = !self._allowTruncationPartThroughWord;
                         // text to be appended at end of visible text
-                        var txtEnd = "...";
+                        var txtEnd = self._truncationEndText;
 
                         // clear any text that's currently there
                         el.innerHTML = "";
@@ -182,7 +184,21 @@ require.def('antie/widgets/label',
 			 */
 			setMaximumLines: function(lines) {
 				this._maxLines = lines;
-			}
+			},
+            /**
+             * Sets the text to append at the end of the truncated text. Default to "..."
+             * @param {String} lines The text to append.
+             */
+            setTruncationEndTxt: function(endTxt) {
+                this._truncationEndText = endTxt;
+            },
+            /**
+             * Allow the text to be truncated part way through a word. Defaults to false.
+             * @param {Boolean} Whether to allow truncating text part way through a word or not.
+             */
+            setAllowTruncationPartThroughWord: function(val) {
+                this._allowTruncationPartThroughWord = val;
+            }
 		});
 
 		/**

--- a/static/script/widgets/label.js
+++ b/static/script/widgets/label.js
@@ -196,6 +196,15 @@ require.def('antie/widgets/label',
              */
             setAllowTruncationPartThroughWord: function(val) {
                 this._allowTruncationPartThroughWord = val;
+            },
+            /**
+             * @Deprecated
+             * Sets the width of this label for use with truncation only.
+             * No longer needed for current method of truncation.
+             * @param {Integer} width The width of this label in pixels
+             */
+            setWidth: function(width) {
+                // TODO: throw deprecated msg
             }
 		});
 

--- a/static/script/widgets/label.js
+++ b/static/script/widgets/label.js
@@ -79,7 +79,12 @@ require.def('antie/widgets/label',
                     // the element needs to already be on the dom for the truncation to work and this happens after the
                     // first render. So if this is the first render, ie this label is not in the dom yet, wait until this
                     // has happened by using a setTimeout with delay of 0. Otherwise do the truncation immediately.
-                    alreadyAddedToDom ? doTruncation() : setTimeout(doTruncation, 0);
+                    if (alreadyAddedToDom) {
+                        doTruncation()
+                    }
+                    else {
+                        setTimeout(doTruncation, 0);
+                    }
 				}
                 else {
                     device.setElementContent(this.outputElement, this._text);

--- a/static/script/widgets/label/texttruncation/cssmanager.js
+++ b/static/script/widgets/label/texttruncation/cssmanager.js
@@ -4,7 +4,13 @@ require.def('antie/widgets/label/texttruncation/cssmanager',
     function () {
         "use strict";
 
-        // save copies of the current css values for the properties that will be changed
+        /**
+         * Saves the elements css and applies changes necessary for text truncation calculations. Then can restore back the original styles.
+         * @name antie.widgets.label.texttruncation.cssmanager
+         * @class
+         * @param {DOMElement} [el] The DOMElement to make the changes on.
+         * @param {Boolean} [configureForMeasuringWidth] Configures the css for measuring the width instead of height.
+         */
         function CssManager(el, configureForMeasuringWidth) {
             this._el = el;
             this._configureForMeasuringWidth = configureForMeasuringWidth;
@@ -18,18 +24,27 @@ require.def('antie/widgets/label/texttruncation/cssmanager',
             this.configureForAlgorithm();
         };
 
+        /**
+         * Saves the current css values on the element which can later be restored with "restore".
+         */
         CssManager.prototype.save = function() {
             for (var prop in this._properties) {
                 this._properties[prop] = this._el.style[prop];
             }
         };
 
+        /**
+         * Restores the original css properties on the element back to the element.
+         */
         CssManager.prototype.restore = function() {
             for (var prop in this._properties) {
                 this._el.style[prop] = this._properties[prop];
             }
         };
 
+        /**
+         * Applies the css properties to the element that are necessary for the text truncation algorithm.
+         */
         CssManager.prototype.configureForAlgorithm = function() {
             // the height should be set to auto so that we can use el.clientHeight to determine the height of the contents
             this._el.style.height = "auto";

--- a/static/script/widgets/label/texttruncation/cssmanager.js
+++ b/static/script/widgets/label/texttruncation/cssmanager.js
@@ -48,7 +48,11 @@ require.def('antie/widgets/label/texttruncation/cssmanager',
                     position: null,
                     whiteSpace: null,
                     width: null,
+                    minWidth: null,
+                    maxWidth: null,
                     height: null,
+                    minHeight: null,
+                    maxHeight: null,
                     display: null
                 };
                 this._save();
@@ -88,6 +92,8 @@ require.def('antie/widgets/label/texttruncation/cssmanager',
              * Applies the css properties to the element that are necessary for the text truncation algorithm.
              */
             configureForAlgorithm: function() {
+                this._el.style.maxHeight = null;
+                this._el.style.minHeight = null;
                 // the height should be set to auto so that we can use el.clientHeight to determine the height of the contents
                 this._el.style.height = "auto";
                 this._el.style.display = "inline-block";
@@ -96,6 +102,8 @@ require.def('antie/widgets/label/texttruncation/cssmanager',
                     // we will be measuring the width that is taken up as text is added so set the width to auto and make sure no wrapping occurs.
                     this._el.style.whiteSpace = "nowrap";
                     this._el.style.width = "auto";
+                    this._el.style.maxWidth = null;
+                    this._el.style.minWidth = null;
                 }
                 else {
                     this._el.style.whiteSpace = "normal";

--- a/static/script/widgets/label/texttruncation/cssmanager.js
+++ b/static/script/widgets/label/texttruncation/cssmanager.js
@@ -1,0 +1,48 @@
+require.def('antie/widgets/label/texttruncation/cssmanager',
+    [
+    ],
+    function () {
+        "use strict";
+
+        // save copies of the current css values for the properties that will be changed
+        function CssManager(el, configureForMeasuringWidth) {
+            this._el = el;
+            this._configureForMeasuringWidth = configureForMeasuringWidth;
+            this._properties = {
+                whiteSpace: null,
+                width: null,
+                height: null,
+                display: null
+            };
+            this.save();
+            this.configureForAlgorithm();
+        };
+
+        CssManager.prototype.save = function() {
+            for (var prop in this._properties) {
+                this._properties[prop] = this._el.style[prop];
+            }
+        };
+
+        CssManager.prototype.restore = function() {
+            for (var prop in this._properties) {
+                this._el.style[prop] = this._properties[prop];
+            }
+        };
+
+        CssManager.prototype.configureForAlgorithm = function() {
+            // the height should be set to auto so that we can use el.clientHeight to determine the height of the contents
+            this._el.style.height = "auto";
+            this._el.style.display = "inline-block";
+            if (this._configureForMeasuringWidth) {
+                // we will be measuring the width that is taken up as text is added so set the width to auto and make sure no wrapping occurs.
+                this._el.style.whiteSpace = "nowrap";
+                this._el.style.width = "auto";
+            }
+            else {
+                this._el.style.whiteSpace = "normal";
+            }
+        };
+        return CssManager;
+    }
+);

--- a/static/script/widgets/label/texttruncation/cssmanager.js
+++ b/static/script/widgets/label/texttruncation/cssmanager.js
@@ -59,7 +59,9 @@ require.def('antie/widgets/label/texttruncation/cssmanager',
              */
             _save: function() {
                 for (var prop in this._properties) {
-                    this._properties[prop] = this._el.style[prop];
+                    if (this._properties.hasOwnProperty(prop)) {
+                        this._properties[prop] = this._el.style[prop];
+                    }
                 }
             },
 
@@ -68,7 +70,9 @@ require.def('antie/widgets/label/texttruncation/cssmanager',
              */
             restore: function() {
                 for (var prop in this._properties) {
-                    this._el.style[prop] = this._properties[prop];
+                    if (this._properties.hasOwnProperty(prop)) {
+                        this._el.style[prop] = this._properties[prop];
+                    }
                 }
             },
 

--- a/static/script/widgets/label/texttruncation/cssmanager.js
+++ b/static/script/widgets/label/texttruncation/cssmanager.js
@@ -4,7 +4,7 @@ require.def('antie/widgets/label/texttruncation/cssmanager',
     ],
     /**
      * Saves the elements css and applies changes necessary for text truncation calculations. Then can restore back the original styles.
-     * @name antie.widgets.label.texttruncation.cssmanager
+     * @name antie.widgets.label.texttruncation.CssManager
      * @class
      * @param {DOMElement} el The DOMElement to make the changes on.
      * @param {Boolean} configureForMeasuringWidth Configures the css for measuring the width instead of height.

--- a/static/script/widgets/label/texttruncation/cssmanager.js
+++ b/static/script/widgets/label/texttruncation/cssmanager.js
@@ -20,14 +20,14 @@ require.def('antie/widgets/label/texttruncation/cssmanager',
                 height: null,
                 display: null
             };
-            this.save();
+            this._save();
             this.configureForAlgorithm();
         };
 
         /**
          * Saves the current css values on the element which can later be restored with "restore".
          */
-        CssManager.prototype.save = function() {
+        CssManager.prototype._save = function() {
             for (var prop in this._properties) {
                 this._properties[prop] = this._el.style[prop];
             }

--- a/static/script/widgets/label/texttruncation/cssmanager.js
+++ b/static/script/widgets/label/texttruncation/cssmanager.js
@@ -1,3 +1,27 @@
+/**
+ * @preserve Copyright (c) 2013 British Broadcasting Corporation
+ * (http://www.bbc.co.uk) and TAL Contributors (1)
+ *
+ * (1) TAL Contributors are listed in the AUTHORS file and at
+ *     https://github.com/fmtvp/TAL/AUTHORS - please extend this file,
+ *     not this notice.
+ *
+ * @license Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * All rights reserved
+ * Please contact us for an alternative licence
+ */
+
 require.def('antie/widgets/label/texttruncation/cssmanager',
     [
         "antie/class"

--- a/static/script/widgets/label/texttruncation/cssmanager.js
+++ b/static/script/widgets/label/texttruncation/cssmanager.js
@@ -51,7 +51,6 @@ require.def('antie/widgets/label/texttruncation/cssmanager',
                     display: null
                 };
                 this._save();
-                this.configureForAlgorithm();
             },
 
             /**
@@ -74,6 +73,13 @@ require.def('antie/widgets/label/texttruncation/cssmanager',
                         this._el.style[prop] = this._properties[prop];
                     }
                 }
+            },
+
+            /**
+             * Set the display mode to block. This means we get the actual width the element could take up even if it's set to 'inline'.
+             */
+            configureForMeasuring: function() {
+                this._el.style.display = "block";
             },
 
             /**

--- a/static/script/widgets/label/texttruncation/cssmanager.js
+++ b/static/script/widgets/label/texttruncation/cssmanager.js
@@ -45,6 +45,7 @@ require.def('antie/widgets/label/texttruncation/cssmanager',
                 this._el = el;
                 this._configureForMeasuringWidth = configureForMeasuringWidth;
                 this._properties = {
+                    position: null,
                     whiteSpace: null,
                     width: null,
                     height: null,
@@ -79,6 +80,7 @@ require.def('antie/widgets/label/texttruncation/cssmanager',
              * Set the display mode to block. This means we get the actual width the element could take up even if it's set to 'inline'.
              */
             configureForMeasuring: function() {
+                this._el.style.position = "static";
                 this._el.style.display = "block";
             },
 
@@ -89,6 +91,7 @@ require.def('antie/widgets/label/texttruncation/cssmanager',
                 // the height should be set to auto so that we can use el.clientHeight to determine the height of the contents
                 this._el.style.height = "auto";
                 this._el.style.display = "inline-block";
+                this._el.style.position = "static";
                 if (this._configureForMeasuringWidth) {
                     // we will be measuring the width that is taken up as text is added so set the width to auto and make sure no wrapping occurs.
                     this._el.style.whiteSpace = "nowrap";

--- a/static/script/widgets/label/texttruncation/cssmanager.js
+++ b/static/script/widgets/label/texttruncation/cssmanager.js
@@ -1,63 +1,70 @@
 require.def('antie/widgets/label/texttruncation/cssmanager',
     [
+        "antie/class"
     ],
-    function () {
+    /**
+     * Saves the elements css and applies changes necessary for text truncation calculations. Then can restore back the original styles.
+     * @name antie.widgets.label.texttruncation.cssmanager
+     * @class
+     * @param {DOMElement} el The DOMElement to make the changes on.
+     * @param {Boolean} configureForMeasuringWidth Configures the css for measuring the width instead of height.
+     */
+    function (Class) {
         "use strict";
+        var CssManager = Class.extend(/** @lends antie.widgets.label.texttruncation.cssmanager*/ {
 
-        /**
-         * Saves the elements css and applies changes necessary for text truncation calculations. Then can restore back the original styles.
-         * @name antie.widgets.label.texttruncation.cssmanager
-         * @class
-         * @param {DOMElement} [el] The DOMElement to make the changes on.
-         * @param {Boolean} [configureForMeasuringWidth] Configures the css for measuring the width instead of height.
-         */
-        function CssManager(el, configureForMeasuringWidth) {
-            this._el = el;
-            this._configureForMeasuringWidth = configureForMeasuringWidth;
-            this._properties = {
-                whiteSpace: null,
-                width: null,
-                height: null,
-                display: null
-            };
-            this._save();
-            this.configureForAlgorithm();
-        };
+            /**
+             * @constructor
+             * @ignore
+             */
+            init: function(el, configureForMeasuringWidth) {
+                this._el = el;
+                this._configureForMeasuringWidth = configureForMeasuringWidth;
+                this._properties = {
+                    whiteSpace: null,
+                    width: null,
+                    height: null,
+                    display: null
+                };
+                this._save();
+                this.configureForAlgorithm();
+            },
 
-        /**
-         * Saves the current css values on the element which can later be restored with "restore".
-         */
-        CssManager.prototype._save = function() {
-            for (var prop in this._properties) {
-                this._properties[prop] = this._el.style[prop];
-            }
-        };
+            /**
+             * Saves the current css values on the element which can later be restored with "restore".
+             */
+            _save: function() {
+                for (var prop in this._properties) {
+                    this._properties[prop] = this._el.style[prop];
+                }
+            },
 
-        /**
-         * Restores the original css properties on the element back to the element.
-         */
-        CssManager.prototype.restore = function() {
-            for (var prop in this._properties) {
-                this._el.style[prop] = this._properties[prop];
-            }
-        };
+            /**
+             * Restores the original css properties on the element back to the element.
+             */
+            restore: function() {
+                for (var prop in this._properties) {
+                    this._el.style[prop] = this._properties[prop];
+                }
+            },
 
-        /**
-         * Applies the css properties to the element that are necessary for the text truncation algorithm.
-         */
-        CssManager.prototype.configureForAlgorithm = function() {
-            // the height should be set to auto so that we can use el.clientHeight to determine the height of the contents
-            this._el.style.height = "auto";
-            this._el.style.display = "inline-block";
-            if (this._configureForMeasuringWidth) {
-                // we will be measuring the width that is taken up as text is added so set the width to auto and make sure no wrapping occurs.
-                this._el.style.whiteSpace = "nowrap";
-                this._el.style.width = "auto";
+            /**
+             * Applies the css properties to the element that are necessary for the text truncation algorithm.
+             */
+            configureForAlgorithm: function() {
+                // the height should be set to auto so that we can use el.clientHeight to determine the height of the contents
+                this._el.style.height = "auto";
+                this._el.style.display = "inline-block";
+                if (this._configureForMeasuringWidth) {
+                    // we will be measuring the width that is taken up as text is added so set the width to auto and make sure no wrapping occurs.
+                    this._el.style.whiteSpace = "nowrap";
+                    this._el.style.width = "auto";
+                }
+                else {
+                    this._el.style.whiteSpace = "normal";
+                }
             }
-            else {
-                this._el.style.whiteSpace = "normal";
-            }
-        };
+        });
         return CssManager;
     }
 );

--- a/static/script/widgets/label/texttruncation/helpers.js
+++ b/static/script/widgets/label/texttruncation/helpers.js
@@ -1,6 +1,6 @@
 require.def('antie/widgets/label/texttruncation/helpers',
-    ['antie/widgets/label/texttruncation/positiongenerator'],
-    function (PositionGenerator) {
+    [],
+    function () {
         "use strict";
 
         return {
@@ -46,25 +46,6 @@ require.def('antie/widgets/label/texttruncation/helpers',
                     str = str.slice(0, str.length - 1);
                 }
                 return str;
-            },
-
-            /**
-             * Perform a binary chop to calculate the number of characters that fit into the WorkContainer.
-             * @param {antie.widgets.label.texttruncation.workcontainer} workContainer The WorkContainer.
-             * @param {String} txt The source string to work on.
-             * @param {String} txtEnd The text that would be added after the truncated text. E.g "...".
-             *                        The length of this is not included in the returned value.
-             * @returns The number of characters that fit in the WorkContainer.
-             */
-            getNumCharactersThatFit: function(workContainer, txt, txtEnd) {
-                var positionGenerator = new PositionGenerator(txt.length);
-                var position = txt.length;
-                var txtWorkingOn = txt;
-                while(positionGenerator.hasNext(workContainer.isOver(txtWorkingOn))) {
-                    position = positionGenerator.next(workContainer.isOver(txtWorkingOn));
-                    txtWorkingOn = txt.slice(0, position) + txtEnd;
-                }
-                return position;
             }
         };
     }

--- a/static/script/widgets/label/texttruncation/helpers.js
+++ b/static/script/widgets/label/texttruncation/helpers.js
@@ -59,12 +59,10 @@ require.def('antie/widgets/label/texttruncation/helpers',
             getNumCharactersThatFit: function(workContainer, txt, txtEnd) {
                 var positionGenerator = new PositionGenerator(txt.length);
                 var position = txt.length;
-                workContainer.setTxt(txt);
-                while(positionGenerator.hasNext(workContainer.isOver())) {
-                    position = positionGenerator.next(workContainer.isOver());
-                    var txtWorkingOn = txt.slice(0, position);
-                    // txtEnd should only be added on last line.
-                    workContainer.setTxt(txtWorkingOn + txtEnd);
+                var txtWorkingOn = txt;
+                while(positionGenerator.hasNext(workContainer.isOver(txtWorkingOn))) {
+                    position = positionGenerator.next(workContainer.isOver(txtWorkingOn));
+                    txtWorkingOn = txt.slice(0, position) + txtEnd;
                 }
                 return position;
             }

--- a/static/script/widgets/label/texttruncation/helpers.js
+++ b/static/script/widgets/label/texttruncation/helpers.js
@@ -4,18 +4,30 @@ require.def('antie/widgets/label/texttruncation/helpers',
         "use strict";
 
         return {
-            // returns true if the result of str sliced to slicePoint would end at a word boundary
+            /**
+             * Determine whether the result of str sliced to slicePoint would end at a word boundary.
+             * @param {String} str The string that will be sliced.
+             * @param {String} slicePoint The point that this string would be sliced at. (Second param of slice)
+             * @returns true or false
+             */
             isAtWordBoundary: function(str, slicePoint) {
                 return slicePoint >= str.length || str[slicePoint] === " ";
             },
 
-            // returns the index of the last word boundary
+            /**
+             * Get the index of the start of the last word boundary in a string.
+             * @param {String} str The string to check.
+             * @returns The index or -1 if no word boundary could be found.
+             */
             getLastWordBoundaryIndex: function(str) {
                 return str.lastIndexOf(" ");
             },
 
-            // returns a trimmed version of str to the end of the last word
-            // this assumes that str is already finishing mid way through a word
+            /**
+             * Trim a string so that it ends after a complete word.
+             * @param {String} str The string to trim.
+             * @returns A trimmed version of the string.
+             */
             trimToWord: function(str) {
                 var lastSpaceIndex = this.getLastWordBoundaryIndex(str);
                 if (lastSpaceIndex !== -1) {
@@ -24,7 +36,11 @@ require.def('antie/widgets/label/texttruncation/helpers',
                 return str;
             },
 
-            // returns str with any trailing whitespace removed
+            /**
+             * Removes whitespace from the end of a string.
+             * @param {String} str The string to remove whitespace from.
+             * @returns The new string with trailing whitespace removed.
+             */
             trimTrailingWhitespace: function(str) {
                 while (str.length > 0 && str[str.length - 1] === " ") {
                     str = str.slice(0, str.length - 1);
@@ -32,7 +48,14 @@ require.def('antie/widgets/label/texttruncation/helpers',
                 return str;
             },
 
-            // perform a binary chop until find number of characters that will fit
+            /**
+             * Perform a binary chop to calculate the number of characters that fit into the WorkContainer.
+             * @param {antie.widgets.label.texttruncation.workcontainer} workContainer The WorkContainer.
+             * @param {String} txt The source string to work on.
+             * @param {String} txtEnd The text that would be added after the truncated text. E.g "...".
+             *                        The length of this is not included in the returned value.
+             * @returns The number of characters that fit in the WorkContainer.
+             */
             getNumCharactersThatFit: function(workContainer, txt, txtEnd) {
                 var positionGenerator = new PositionGenerator(txt.length);
                 var position = txt.length;

--- a/static/script/widgets/label/texttruncation/helpers.js
+++ b/static/script/widgets/label/texttruncation/helpers.js
@@ -33,7 +33,7 @@ require.def('antie/widgets/label/texttruncation/helpers',
                 if (lastSpaceIndex !== -1) {
                     return str.slice(0, lastSpaceIndex);
                 }
-                return str;
+                return "";
             },
 
             /**

--- a/static/script/widgets/label/texttruncation/helpers.js
+++ b/static/script/widgets/label/texttruncation/helpers.js
@@ -1,3 +1,27 @@
+/**
+ * @preserve Copyright (c) 2013 British Broadcasting Corporation
+ * (http://www.bbc.co.uk) and TAL Contributors (1)
+ *
+ * (1) TAL Contributors are listed in the AUTHORS file and at
+ *     https://github.com/fmtvp/TAL/AUTHORS - please extend this file,
+ *     not this notice.
+ *
+ * @license Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * All rights reserved
+ * Please contact us for an alternative licence
+ */
+
 require.def('antie/widgets/label/texttruncation/helpers',
     [],
     function () {

--- a/static/script/widgets/label/texttruncation/helpers.js
+++ b/static/script/widgets/label/texttruncation/helpers.js
@@ -1,0 +1,50 @@
+require.def('antie/widgets/label/texttruncation/helpers',
+    ['antie/widgets/label/texttruncation/positiongenerator'],
+    function (PositionGenerator) {
+        "use strict";
+
+        return {
+            // returns true if the result of str sliced to slicePoint would end at a word boundary
+            isAtWordBoundary: function(str, slicePoint) {
+                return slicePoint >= str.length || str[slicePoint] === " ";
+            },
+
+            // returns the index of the last word boundary
+            getLastWordBoundaryIndex: function(str) {
+                return str.lastIndexOf(" ");
+            },
+
+            // returns a trimmed version of str to the end of the last word
+            // this assumes that str is already finishing mid way through a word
+            trimToWord: function(str) {
+                var lastSpaceIndex = this.getLastWordBoundaryIndex(str);
+                if (lastSpaceIndex !== -1) {
+                    return str.slice(0, lastSpaceIndex);
+                }
+                return str;
+            },
+
+            // returns str with any trailing whitespace removed
+            trimTrailingWhitespace: function(str) {
+                while (str.length > 0 && str[str.length - 1] === " ") {
+                    str = str.slice(0, str.length - 1);
+                }
+                return str;
+            },
+
+            // perform a binary chop until find number of characters that will fit
+            getNumCharactersThatFit: function(workContainer, txt, txtEnd) {
+                var positionGenerator = new PositionGenerator(txt.length);
+                var position = txt.length;
+                workContainer.setTxt(txt);
+                while(positionGenerator.hasNext(workContainer.isOver())) {
+                    position = positionGenerator.next(workContainer.isOver());
+                    var txtWorkingOn = txt.slice(0, position);
+                    // txtEnd should only be added on last line.
+                    workContainer.setTxt(txtWorkingOn + txtEnd);
+                }
+                return position;
+            }
+        };
+    }
+);

--- a/static/script/widgets/label/texttruncation/helpers.js
+++ b/static/script/widgets/label/texttruncation/helpers.js
@@ -7,7 +7,7 @@ require.def('antie/widgets/label/texttruncation/helpers',
             /**
              * Determine whether the result of str sliced to slicePoint would end at a word boundary.
              * @param {String} str The string that will be sliced.
-             * @param {String} slicePoint The point that this string would be sliced at. (Second param of slice)
+             * @param {Number} slicePoint The point that this string would be sliced at. (Second param of slice)
              * @returns true or false
              */
             isAtWordBoundary: function(str, slicePoint) {

--- a/static/script/widgets/label/texttruncation/positiongenerator.js
+++ b/static/script/widgets/label/texttruncation/positiongenerator.js
@@ -7,10 +7,10 @@ require.def('antie/widgets/label/texttruncation/positiongenerator',
         /**
          * Generates the index in the string that the algorithm should look up to (but not include) to determine the
          * amount of text that will fit.
-         * Starts with a value of 2^n which is just over or equal to the text length. This value is then halved on each
-         * request and either added or subtracted from the current position that is being looked at in the string depending
-         * on whether the amount of text is over or under the amount that will fit. A negative value converted to 0 and a
-         * value higher than the text length is converted to the text length.
+         * Starts with a value of 2^n which is just over or equal to the text length. Then halves this value. This value
+         * is then halved on each request and either added or subtracted from the current position that is being looked
+         * at in the string depending on whether the amount of text is over or under the amount that will fit. A negative
+         * value converted to 0.
          * @name antie.widgets.label.texttruncation.positiongenerator
          * @class
          * @param {String} [txtLength] The length of the source string.
@@ -22,6 +22,7 @@ require.def('antie/widgets/label/texttruncation/positiongenerator',
             while (this._pointer < this._txtLength) {
                 this._pointer = this._pointer << 1;
             }
+            this._pointer = this._pointer >> 1;
         }
 
         /**
@@ -37,9 +38,6 @@ require.def('antie/widgets/label/texttruncation/positiongenerator',
 
             if (nextPos < 0) {
                 nextPos = 0;
-            }
-            else if (nextPos > this._txtLength) {
-                nextPos = this._txtLength;
             }
             return nextPos;
         };

--- a/static/script/widgets/label/texttruncation/positiongenerator.js
+++ b/static/script/widgets/label/texttruncation/positiongenerator.js
@@ -1,7 +1,8 @@
 require.def('antie/widgets/label/texttruncation/positiongenerator',
     [
+        "antie/class"
     ],
-    function () {
+    function (Class) {
         "use strict";
 
         /**
@@ -11,64 +12,73 @@ require.def('antie/widgets/label/texttruncation/positiongenerator',
          * is then halved on each request and either added or subtracted from the current position that is being looked
          * at in the string depending on whether the amount of text is over or under the amount that will fit. A negative
          * value converted to 0.
-         * @name antie.widgets.label.texttruncation.positiongenerator
+         * @name antie.widgets.label.texttruncation.PositionGenerator
          * @class
          * @param {String} [txtLength] The length of the source string.
          */
-        function PositionGenerator(txtLength) {
-            this._txtLength = txtLength;
-            this._position = this._txtLength;
-            this._pointer = 1;
-            while (this._pointer < this._txtLength) {
-                this._pointer = this._pointer << 1;
+        var PositionGenerator = Class.extend(/** @lends antie.widgets.label.texttruncation.positiongenerator.prototype */ {
+
+            /**
+             * @constructor
+             * @ignore
+             */
+            init: function(txtLength) {
+                this._txtLength = txtLength;
+                this._position = this._txtLength;
+                this._pointer = 1;
+                while (this._pointer < this._txtLength) {
+                    this._pointer = this._pointer << 1;
+                }
+                this._pointer = this._pointer >> 1;
+            },
+
+            _calculateNext: function(isOver) {
+                var self = this;
+                var nextPos;
+
+                function getNextPointerValOrOneIfOverAndPointerIsZero() {
+                    return self._pointer === 0 && isOver ? 1 : self._pointer
+                }
+                var amount = getNextPointerValOrOneIfOverAndPointerIsZero();
+                nextPos = isOver ? this._position - amount : this._position + amount;
+
+                if (nextPos < 0) {
+                    nextPos = 0;
+                }
+                return nextPos;
+            },
+
+            /**
+             * Returns the position that the source text should be sliced up to next and also registers that this position
+             * has been used so the next call of this or 'calculateNext' would be the next position to check.
+             * @param {Boolean} [isOver] True if the source string currently takes up more space than the container when
+             *                           sliced to the last position retrieved from 'next'.
+             * @returns The position that the source text should be sliced up to next.
+             */
+            next: function(isOver) {
+               this._position = this._calculateNext(isOver);
+               this._pointer = this._pointer >> 1;
+               return this._position;
+            },
+
+            /**
+             * Returns the position that the source text should be sliced up to next and also registers that this position
+             * has been used so the next call of this or 'calculateNext' would be the next position to check.
+             * @param {Boolean} [isOver] True if the source string currently takes up more space than the container when
+             *                           sliced to the last position retrieved from 'next'.
+             * @returns The true if there is another position to check.
+             */
+            hasNext: function(isOver) {
+                if (this._position === this._txtLength && !isOver) {
+                    return false;
+                }
+                else if (this._position === 0 && isOver) {
+                    return false;
+                }
+                return this._pointer > 0 || isOver;
             }
-            this._pointer = this._pointer >> 1;
-        }
 
-        PositionGenerator.prototype._calculateNext = function(isOver) {
-            var nextPos;
-
-            function someDescriptiveName() {
-
-            }
-            var amount = this._pointer === 0 && isOver ? 1 : this._pointer;
-            nextPos = isOver ? this._position - amount : this._position + amount;
-
-            if (nextPos < 0) {
-                nextPos = 0;
-            }
-            return nextPos;
-        };
-
-        /**
-         * Returns the position that the source text should be sliced up to next and also registers that this position
-         * has been used so the next call of this or 'calculateNext' would be the next position to check.
-         * @param {Boolean} [isOver] True if the source string currently takes up more space than the container when
-         *                           sliced to the last position retrieved from 'next'.
-         * @returns The position that the source text should be sliced up to next.
-         */
-        PositionGenerator.prototype.next = function(isOver) {
-            this._position = this._calculateNext(isOver);
-            this._pointer = this._pointer >> 1;
-            return this._position;
-        };
-
-        /**
-         * Returns the position that the source text should be sliced up to next and also registers that this position
-         * has been used so the next call of this or 'calculateNext' would be the next position to check.
-         * @param {Boolean} [isOver] True if the source string currently takes up more space than the container when
-         *                           sliced to the last position retrieved from 'next'.
-         * @returns The true if there is another position to check.
-         */
-        PositionGenerator.prototype.hasNext = function(isOver) {
-            if (this._position === this._txtLength && !isOver) {
-                return false;
-            }
-            else if (this._position === 0 && isOver) {
-                return false;
-            }
-            return this._pointer > 0 || isOver;
-        };
+        });
 
         return PositionGenerator;
     }

--- a/static/script/widgets/label/texttruncation/positiongenerator.js
+++ b/static/script/widgets/label/texttruncation/positiongenerator.js
@@ -1,0 +1,50 @@
+require.def('antie/widgets/label/texttruncation/positiongenerator',
+    [
+    ],
+    function () {
+        "use strict";
+
+        function PositionGenerator(txtLength) {
+            this._txtLength = txtLength;
+            this._position = this._txtLength;
+            this._pointer = 1;
+            while (this._pointer < this._txtLength) {
+                this._pointer = this._pointer << 1;
+            }
+        }
+
+        // get the next position to slice the text at. (Second parameter of .slice)
+        // a position of 2 means up to but not including the second character.
+        PositionGenerator.prototype.calculateNext = function(isOver) {
+            var nextPos;
+            var amount = this._pointer === 0 && isOver ? 1 : this._pointer;
+            nextPos = isOver ? this._position - amount : this._position + amount;
+
+            if (nextPos < 0) {
+                nextPos = 0;
+            }
+            else if (nextPos > this._txtLength) {
+                nextPos = this._txtLength;
+            }
+            return nextPos;
+        };
+
+        PositionGenerator.prototype.next = function(isOver) {
+            this._position = this.calculateNext(isOver);
+            this._pointer = this._pointer >> 1;
+            return this._position;
+        };
+
+        PositionGenerator.prototype.hasNext = function(isOver) {
+            if (this._position === this._txtLength && !isOver) {
+                return false;
+            }
+            else if (this._position === 0 && isOver) {
+                return false;
+            }
+            return this._pointer > 0 || isOver;
+        };
+
+        return PositionGenerator;
+    }
+);

--- a/static/script/widgets/label/texttruncation/positiongenerator.js
+++ b/static/script/widgets/label/texttruncation/positiongenerator.js
@@ -4,6 +4,17 @@ require.def('antie/widgets/label/texttruncation/positiongenerator',
     function () {
         "use strict";
 
+        /**
+         * Generates the index in the string that the algorithm should look up to (but not include) to determine the
+         * amount of text that will fit.
+         * Starts with a value of 2^n which is just over or equal to the text length. This value is then halved on each
+         * request and either added or subtracted from the current position that is being looked at in the string depending
+         * on whether the amount of text is over or under the amount that will fit. A negative value converted to 0 and a
+         * value higher than the text length is converted to the text length.
+         * @name antie.widgets.label.texttruncation.positiongenerator
+         * @class
+         * @param {String} [txtLength] The length of the source string.
+         */
         function PositionGenerator(txtLength) {
             this._txtLength = txtLength;
             this._position = this._txtLength;
@@ -13,8 +24,12 @@ require.def('antie/widgets/label/texttruncation/positiongenerator',
             }
         }
 
-        // get the next position to slice the text at. (Second parameter of .slice)
-        // a position of 2 means up to but not including the second character.
+        /**
+         * Returns the position that the source text should be sliced up to next.
+         * @param {Boolean} [isOver] True if the source string currently takes up more space than the container when
+         *                           sliced to the last position retrieved from 'next'.
+         * @returns The position that the source text should be sliced up to next.
+         */
         PositionGenerator.prototype.calculateNext = function(isOver) {
             var nextPos;
             var amount = this._pointer === 0 && isOver ? 1 : this._pointer;
@@ -29,12 +44,26 @@ require.def('antie/widgets/label/texttruncation/positiongenerator',
             return nextPos;
         };
 
+        /**
+         * Returns the position that the source text should be sliced up to next and also registers that this position
+         * has been used so the next call of this or 'calculateNext' would be the next position to check.
+         * @param {Boolean} [isOver] True if the source string currently takes up more space than the container when
+         *                           sliced to the last position retrieved from 'next'.
+         * @returns The position that the source text should be sliced up to next.
+         */
         PositionGenerator.prototype.next = function(isOver) {
             this._position = this.calculateNext(isOver);
             this._pointer = this._pointer >> 1;
             return this._position;
         };
 
+        /**
+         * Returns the position that the source text should be sliced up to next and also registers that this position
+         * has been used so the next call of this or 'calculateNext' would be the next position to check.
+         * @param {Boolean} [isOver] True if the source string currently takes up more space than the container when
+         *                           sliced to the last position retrieved from 'next'.
+         * @returns The true if there is another position to check.
+         */
         PositionGenerator.prototype.hasNext = function(isOver) {
             if (this._position === this._txtLength && !isOver) {
                 return false;

--- a/static/script/widgets/label/texttruncation/positiongenerator.js
+++ b/static/script/widgets/label/texttruncation/positiongenerator.js
@@ -1,3 +1,27 @@
+/**
+ * @preserve Copyright (c) 2013 British Broadcasting Corporation
+ * (http://www.bbc.co.uk) and TAL Contributors (1)
+ *
+ * (1) TAL Contributors are listed in the AUTHORS file and at
+ *     https://github.com/fmtvp/TAL/AUTHORS - please extend this file,
+ *     not this notice.
+ *
+ * @license Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * All rights reserved
+ * Please contact us for an alternative licence
+ */
+
 require.def('antie/widgets/label/texttruncation/positiongenerator',
     [
         "antie/class"

--- a/static/script/widgets/label/texttruncation/positiongenerator.js
+++ b/static/script/widgets/label/texttruncation/positiongenerator.js
@@ -25,14 +25,12 @@ require.def('antie/widgets/label/texttruncation/positiongenerator',
             this._pointer = this._pointer >> 1;
         }
 
-        /**
-         * Returns the position that the source text should be sliced up to next.
-         * @param {Boolean} [isOver] True if the source string currently takes up more space than the container when
-         *                           sliced to the last position retrieved from 'next'.
-         * @returns The position that the source text should be sliced up to next.
-         */
-        PositionGenerator.prototype.calculateNext = function(isOver) {
+        PositionGenerator.prototype._calculateNext = function(isOver) {
             var nextPos;
+
+            function someDescriptiveName() {
+
+            }
             var amount = this._pointer === 0 && isOver ? 1 : this._pointer;
             nextPos = isOver ? this._position - amount : this._position + amount;
 
@@ -50,7 +48,7 @@ require.def('antie/widgets/label/texttruncation/positiongenerator',
          * @returns The position that the source text should be sliced up to next.
          */
         PositionGenerator.prototype.next = function(isOver) {
-            this._position = this.calculateNext(isOver);
+            this._position = this._calculateNext(isOver);
             this._pointer = this._pointer >> 1;
             return this._position;
         };

--- a/static/script/widgets/label/texttruncation/positiongenerator.js
+++ b/static/script/widgets/label/texttruncation/positiongenerator.js
@@ -14,7 +14,7 @@ require.def('antie/widgets/label/texttruncation/positiongenerator',
          * value converted to 0.
          * @name antie.widgets.label.texttruncation.PositionGenerator
          * @class
-         * @param {String} [txtLength] The length of the source string.
+         * @param {Number} txtLength The length of the source string.
          */
         var PositionGenerator = Class.extend(/** @lends antie.widgets.label.texttruncation.positiongenerator.prototype */ {
 
@@ -33,13 +33,10 @@ require.def('antie/widgets/label/texttruncation/positiongenerator',
             },
 
             _calculateNext: function(isOver) {
-                var self = this;
                 var nextPos;
 
-                function getNextPointerValOrOneIfOverAndPointerIsZero() {
-                    return self._pointer === 0 && isOver ? 1 : self._pointer
-                }
-                var amount = getNextPointerValOrOneIfOverAndPointerIsZero();
+               // get next pointer val or one if over and pointer is zero
+                var amount = this._pointer === 0 && isOver ? 1 : this._pointer;
                 nextPos = isOver ? this._position - amount : this._position + amount;
 
                 if (nextPos < 0) {
@@ -51,8 +48,8 @@ require.def('antie/widgets/label/texttruncation/positiongenerator',
             /**
              * Returns the position that the source text should be sliced up to next and also registers that this position
              * has been used so the next call of this or 'calculateNext' would be the next position to check.
-             * @param {Boolean} [isOver] True if the source string currently takes up more space than the container when
-             *                           sliced to the last position retrieved from 'next'.
+             * @param {Boolean} isOver True if the source string currently takes up more space than the container when
+             *                         sliced to the last position retrieved from 'next'.
              * @returns The position that the source text should be sliced up to next.
              */
             next: function(isOver) {
@@ -64,8 +61,8 @@ require.def('antie/widgets/label/texttruncation/positiongenerator',
             /**
              * Returns the position that the source text should be sliced up to next and also registers that this position
              * has been used so the next call of this or 'calculateNext' would be the next position to check.
-             * @param {Boolean} [isOver] True if the source string currently takes up more space than the container when
-             *                           sliced to the last position retrieved from 'next'.
+             * @param {Boolean} isOver True if the source string currently takes up more space than the container when
+             *                         sliced to the last position retrieved from 'next'.
              * @returns The true if there is another position to check.
              */
             hasNext: function(isOver) {

--- a/static/script/widgets/label/texttruncation/truncator.js
+++ b/static/script/widgets/label/texttruncation/truncator.js
@@ -29,24 +29,51 @@ require.def('antie/widgets/label/texttruncation/truncator',
         'antie/widgets/label/texttruncation/helpers'
     ],
     /**
-     * TODO: this
-     *
+     * The Truncator manages truncating text.
+     * @name antie.widgets.label.texttruncation.Truncator
+     * @class
+     * @param {antie.devices.Device} [device] The antie.devices.Device object currently running this application.
+     * @extends antie.Class
      */
     function (Class, WorkContainer, TruncationHelpers) {
         "use strict";
         var Truncator = Class.extend(/** @lends antie.widgets.label.texttruncation.truncator.prototype */ {
 
-            // TODO: doc
+            /**
+             * @constructor
+             * @ignore
+             */
+            init: function(device) {
+                this._device = device;
+            },
+
+            /**
+             * Set whether or not the text should truncate at a word boundary or any character.
+             * @param {Boolean} splitAtWordBoundary True if you want the text to truncate at a word boundary.
+             */
             setSplitAtWordBoundary: function(splitAtWordBoundary) {
                 this._splitAtWordBoundary = splitAtWordBoundary;
             },
 
-            // TODO: doc
+            /**
+             * Set the text that you want to be appended after the truncated text. This will not be appended if no
+             * truncation occurs.
+             * @param {String} ellipsisText The text to use. E.g. "...".
+             */
             setEllipsisText: function(ellipsisText) {
                 this._ellipsisText = ellipsisText;
             },
 
-            // TODO: doc
+            /**
+             * Truncates text.
+             * @param {DOMElement} element The DOMElement that the text will be placed into. The dimensions of this
+             *                             DOMElement are used to determine where the text will truncate.
+             * @param {String} text The source text.
+             * // TODO: mark this as optional
+             * @param {Number} numberOfLinesRequired The number of lines the text should be truncated to. A value of 0
+             *                                       (or omitting this parameter) means the text should be truncated to
+             *                                       fit the container.
+             */
             truncateText: function (element, text, numberOfLinesRequired) {
 
                 numberOfLinesRequired = numberOfLinesRequired || 0;
@@ -55,7 +82,7 @@ require.def('antie/widgets/label/texttruncation/truncator',
                 element.innerHTML = "";
 
                 var measuringHorizontally = numberOfLinesRequired !== 0;
-                var workContainer = new WorkContainer(element, measuringHorizontally);
+                var workContainer = new WorkContainer(this._device, element, measuringHorizontally);
                 var finalTxt = this._doTruncation(text, workContainer, numberOfLinesRequired);
                 var truncationHappened = finalTxt.length !== text.length;
 

--- a/static/script/widgets/label/texttruncation/truncator.js
+++ b/static/script/widgets/label/texttruncation/truncator.js
@@ -46,6 +46,8 @@ require.def('antie/widgets/label/texttruncation/truncator',
              */
             init: function(device) {
                 this._device = device;
+                this._splitAtWordBoundary = true;
+                this._ellipsisText = "...";
             },
 
             /**
@@ -78,9 +80,6 @@ require.def('antie/widgets/label/texttruncation/truncator',
 
                 numberOfLinesRequired = numberOfLinesRequired || 0;
 
-                // clear any text that's currently there
-                element.innerHTML = "";
-
                 var measuringHorizontally = numberOfLinesRequired !== 0;
                 var workContainer = new WorkContainer(this._device, element, measuringHorizontally);
                 var finalTxt = this._doTruncation(text, workContainer, numberOfLinesRequired);
@@ -102,10 +101,14 @@ require.def('antie/widgets/label/texttruncation/truncator',
 
             _doTruncation: function(text, workContainer, numberOfLinesRequired) {
 
+                // determine if the text actually needs to be truncated
+                if (workContainer.getNumCharactersThatFit(text, "") === text.length) {
+                    // text does not need truncating
+                    return text;
+                }
+
                 // to contain the final text
                 var finalTxt = "";
-                // whether or not truncation actually happened/was necessary
-                var truncationHappened = false;
                 // the index of the text where the current line starts
                 var currentLineStartIndex = 0;
                 var numLoopIterations = numberOfLinesRequired === 0 ? 1 : numberOfLinesRequired;
@@ -115,7 +118,8 @@ require.def('antie/widgets/label/texttruncation/truncator',
                 for (var currentLineNumber = 0; currentLineNumber < numLoopIterations; currentLineNumber++) {
                     var remainingTxt = text.slice(currentLineStartIndex, text.length);
                     var numCharsThatFit = workContainer.getNumCharactersThatFit(remainingTxt, this._getEllipsisIfNecessary(numberOfLinesRequired, currentLineNumber));
-                    truncationHappened = numCharsThatFit !== remainingTxt.length;
+                    // whether or not truncation actually happened/was necessary on this line
+                    var truncationHappened = numCharsThatFit !== remainingTxt.length;
                     var currentLineTxt = remainingTxt.slice(0, numCharsThatFit);
 
                     if (numberOfLinesRequired !== 0 && truncationHappened && currentLineNumber < numberOfLinesRequired - 1) {

--- a/static/script/widgets/label/texttruncation/truncator.js
+++ b/static/script/widgets/label/texttruncation/truncator.js
@@ -28,15 +28,16 @@ require.def('antie/widgets/label/texttruncation/truncator',
         'antie/widgets/label/texttruncation/workcontainer',
         'antie/widgets/label/texttruncation/helpers'
     ],
-    /**
-     * The Truncator manages truncating text.
-     * @name antie.widgets.label.texttruncation.Truncator
-     * @class
-     * @param {antie.devices.Device} [device] The antie.devices.Device object currently running this application.
-     * @extends antie.Class
-     */
     function (Class, WorkContainer, TruncationHelpers) {
         "use strict";
+
+        /**
+         * The Truncator manages truncating text.
+         * @name antie.widgets.label.texttruncation.Truncator
+         * @class
+         * @param {antie.devices.Device} [device] The antie.devices.Device object currently running this application.
+         * @extends antie.Class
+         */
         var Truncator = Class.extend(/** @lends antie.widgets.label.texttruncation.truncator.prototype */ {
 
             /**

--- a/static/script/widgets/label/texttruncation/truncator.js
+++ b/static/script/widgets/label/texttruncation/truncator.js
@@ -72,7 +72,7 @@ require.def('antie/widgets/label/texttruncation/truncator',
              * @param {DOMElement} element The DOMElement that the text will be placed into. The dimensions of this
              *                             DOMElement are used to determine where the text will truncate.
              * @param {String} text The source text.
-             * @param {Number} [numberOfLinesRequired] The number of lines the text should be truncated to. A value of 0
+             * @param {Number} [numberOfLinesRequired] The number of lines the text should be truncated to. A value of null
              *                                         (or omitting this parameter) means the text should be truncated to
              *                                         fit the container.
              */

--- a/static/script/widgets/label/texttruncation/truncator.js
+++ b/static/script/widgets/label/texttruncation/truncator.js
@@ -1,0 +1,125 @@
+/**
+ * @preserve Copyright (c) 2013 British Broadcasting Corporation
+ * (http://www.bbc.co.uk) and TAL Contributors (1)
+ *
+ * (1) TAL Contributors are listed in the AUTHORS file and at
+ *     https://github.com/fmtvp/TAL/AUTHORS - please extend this file,
+ *     not this notice.
+ *
+ * @license Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * All rights reserved
+ * Please contact us for an alternative licence
+ */
+
+require.def('antie/widgets/label/texttruncation/truncator',
+    [
+        "antie/class",
+        'antie/widgets/label/texttruncation/workcontainer',
+        'antie/widgets/label/texttruncation/helpers'
+    ],
+    /**
+     * TODO: this
+     *
+     */
+    function (Class, WorkContainer, TruncationHelpers) {
+        "use strict";
+        var Truncator = Class.extend(/** @lends antie.widgets.label.texttruncation.truncator.prototype */ {
+
+            // TODO: doc
+            setSplitAtWordBoundary: function(splitAtWordBoundary) {
+                this._splitAtWordBoundary = splitAtWordBoundary;
+            },
+
+            // TODO: doc
+            setEllipsisText: function(ellipsisText) {
+                this._ellipsisText = ellipsisText;
+            },
+
+            // TODO: doc
+            truncateText: function (element, text, numberOfLinesRequired) {
+
+                numberOfLinesRequired = numberOfLinesRequired || 0;
+
+                // clear any text that's currently there
+                element.innerHTML = "";
+
+                var measuringHorizontally = numberOfLinesRequired !== 0;
+                var workContainer = new WorkContainer(element, measuringHorizontally);
+                var finalTxt = this._doTruncation(text, workContainer, numberOfLinesRequired);
+                var truncationHappened = finalTxt.length !== text.length;
+
+                if (truncationHappened) {
+                    // ensure string cuts off after a complete word (if that option enabled)
+                    if (this._splitAtWordBoundary && !TruncationHelpers.isAtWordBoundary(text, finalTxt.length)) {
+                        finalTxt = TruncationHelpers.trimToWord(finalTxt);
+                    }
+                    // trim trailing spaces
+                    finalTxt = TruncationHelpers.trimTrailingWhitespace(finalTxt);
+                    // add txtEnd
+                    finalTxt += this._ellipsisText;
+                }
+                workContainer.destroy();
+                return finalTxt;
+            },
+
+            _doTruncation: function(text, workContainer, numberOfLinesRequired) {
+
+                // to contain the final text
+                var finalTxt = "";
+                // whether or not truncation actually happened/was necessary
+                var truncationHappened = false;
+                // the index of the text where the current line starts
+                var currentLineStartIndex = 0;
+                var numLoopIterations = numberOfLinesRequired === 0 ? 1 : numberOfLinesRequired;
+
+                // the loop will run for each line. If this is run with noLines as 0 this means fit the height of the label.
+                // in this case the loop should only run once as it's the height that's being measured.
+                for (var currentLineNumber = 0; currentLineNumber < numLoopIterations; currentLineNumber++) {
+                    var remainingTxt = text.slice(currentLineStartIndex, text.length);
+                    var numCharsThatFit = workContainer.getNumCharactersThatFit(remainingTxt, this._getEllipsisIfNecessary(numberOfLinesRequired, currentLineNumber));
+                    truncationHappened = numCharsThatFit !== remainingTxt.length;
+                    var currentLineTxt = remainingTxt.slice(0, numCharsThatFit);
+
+                    if (numberOfLinesRequired !== 0 && truncationHappened && currentLineNumber < numberOfLinesRequired - 1) {
+                        // moving onto next line
+                        // update startIndex to the index that the next line will start on.
+                        // will be after the last space on line
+                        var lastWordBoundary = TruncationHelpers.getLastWordBoundaryIndex(currentLineTxt);
+                        if (lastWordBoundary !== -1) {
+                            currentLineStartIndex = currentLineStartIndex + (lastWordBoundary + 1);
+                            // slice currentLineTxt so that it matches the text that will be on the line
+                            currentLineTxt = currentLineTxt.slice(0, lastWordBoundary + 1);
+                        }
+                        else {
+                            currentLineStartIndex = numCharsThatFit;
+                        }
+                    }
+                    finalTxt += currentLineTxt;
+
+                    if (!truncationHappened) {
+                        // no point carrying on if not had to truncate on this line as this will be the same for the rest
+                        break;
+                    }
+                }
+                return finalTxt;
+            },
+
+            _getEllipsisIfNecessary: function(numberOfLinesRequired, currentLineNumber) {
+                return numberOfLinesRequired === 0 || currentLineNumber === numberOfLinesRequired - 1 ? this._ellipsisText : "";
+            }
+        });
+
+        return Truncator;
+    }
+);

--- a/static/script/widgets/label/texttruncation/truncator.js
+++ b/static/script/widgets/label/texttruncation/truncator.js
@@ -70,10 +70,9 @@ require.def('antie/widgets/label/texttruncation/truncator',
              * @param {DOMElement} element The DOMElement that the text will be placed into. The dimensions of this
              *                             DOMElement are used to determine where the text will truncate.
              * @param {String} text The source text.
-             * // TODO: mark this as optional
-             * @param {Number} numberOfLinesRequired The number of lines the text should be truncated to. A value of 0
-             *                                       (or omitting this parameter) means the text should be truncated to
-             *                                       fit the container.
+             * @param {Number} [numberOfLinesRequired] The number of lines the text should be truncated to. A value of 0
+             *                                         (or omitting this parameter) means the text should be truncated to
+             *                                         fit the container.
              */
             truncateText: function (element, text, numberOfLinesRequired) {
 

--- a/static/script/widgets/label/texttruncation/workcontainer.js
+++ b/static/script/widgets/label/texttruncation/workcontainer.js
@@ -1,3 +1,27 @@
+/**
+ * @preserve Copyright (c) 2013 British Broadcasting Corporation
+ * (http://www.bbc.co.uk) and TAL Contributors (1)
+ *
+ * (1) TAL Contributors are listed in the AUTHORS file and at
+ *     https://github.com/fmtvp/TAL/AUTHORS - please extend this file,
+ *     not this notice.
+ *
+ * @license Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * All rights reserved
+ * Please contact us for an alternative licence
+ */
+
 require.def('antie/widgets/label/texttruncation/workcontainer',
     [
         "antie/class",

--- a/static/script/widgets/label/texttruncation/workcontainer.js
+++ b/static/script/widgets/label/texttruncation/workcontainer.js
@@ -12,14 +12,14 @@ require.def('antie/widgets/label/texttruncation/workcontainer',
          * The container will be set to fill the parent element and the visibility will be set to hidden and overflow to
          * hidden on this container to make sure any temporary work isn't visible and doesn't effect anything else on the page.
          * Because the text node is being created under the parent element in the dom hireachy so that it inherits all of the correct css styles.
-         * @name antie.widgets.label.texttruncation.workcontainer
+         * @name antie.widgets.label.texttruncation.WorkContainer
          * @class
          * @param {antie.devices.Device} [device] The antie.devices.Device object currently running this application.
          * @param {DOMElement} [parentEl] The DOMElement that should contain this.
          * @param {Boolean} [measuringHorizontally] True if this container is being used to compare the width of the text to the width of the container.
          *                                          False if the container is being used to compare the height of the text to the height of the container.
          */
-        var WorkContainer = Class.extend(/** @lends antie.widgets.label.texttruncation.workcontainer.prototype */ {
+         var WorkContainer = Class.extend(/** @lends antie.widgets.label.texttruncation.workcontainer.prototype */ {
 
             /**
              * @constructor

--- a/static/script/widgets/label/texttruncation/workcontainer.js
+++ b/static/script/widgets/label/texttruncation/workcontainer.js
@@ -4,10 +4,17 @@ require.def('antie/widgets/label/texttruncation/workcontainer',
     function () {
         "use strict";
 
-        // put the text node that we will be working on inside a container in the target el.
-        // the container will be set to fill the main element
-        // this means we can set the visibility to hidden and overflow to hidden on this container to make sure any temporary work isn't visible and doesn't effect anything else on the page.
-        // the text node must be created under the el in the dom hireachy so that it inherits all the correct css styles.
+        /**
+         * A wrapper for the container which will contain the textnode which will be used for calculations.
+         * The container will be set to fill the parent element and the visibility will be set to hidden and overflow to
+         * hidden on this container to make sure any temporary work isn't visible and doesn't effect anything else on the page.
+         * Because the text node is being created under the parent element in the dom hireachy so that it inherits all of the correct css styles.
+         * @name antie.widgets.label.texttruncation.workcontainer
+         * @class
+         * @param {DOMElement} [parentEl] The DOMElement that should contain this.
+         * @param {Boolean} [measuringHorizontally] True if this container is being used to compare the width of the text to the width of the container.
+         *                                          False if the container is being used to compare the height of the text to the height of the container.
+         */
         function WorkContainer(parentEl, measuringHorizontally) {
             this._parentEl = parentEl;
             this._measuringHorizontally = measuringHorizontally;
@@ -35,19 +42,29 @@ require.def('antie/widgets/label/texttruncation/workcontainer',
             this._parentEl.appendChild(this._container);
         };
 
+        /**
+         * Destroy the container and the text node contained in it.
+         */
         WorkContainer.prototype.destroy = function() {
             this._container.removeChild(this._txtTruncationElNode); //TODO: check this is necessary
             this._parentEl.removeChild(this._container);
         };
 
+        /**
+         * Set the text on the text node in the container.
+         * @param {String} [txt] The text to place in the text node.
+         */
         WorkContainer.prototype.setTxt = function(txt) {
             this._txtTruncationElNode.nodeValue = txt;
         };
 
+        /**
+         * Determine if the current text in the text node either overflows the width if measuring horizontally, or height otherwise.
+         * @returns True if the text is overflowing the container.
+         */
         WorkContainer.prototype.isOver = function() {
             return this._measuringHorizontally ? this._container.clientWidth > this.w : this._container.clientHeight > this.h;
         };
-
         return WorkContainer;
     }
 );

--- a/static/script/widgets/label/texttruncation/workcontainer.js
+++ b/static/script/widgets/label/texttruncation/workcontainer.js
@@ -24,8 +24,8 @@ require.def('antie/widgets/label/texttruncation/workcontainer',
             // the width and height of the box that the text should be truncated to fit into.
             // use the container (which has width auto and height 100%) clientWidth and clientHeight to get this value, not the parent el, because this takes into consideration any padding on the parent el
             // clientWidth and clientHeight includes padding (but not border or margin), but we know that container will have padding of 0 and will sit within parents padding :)
-            this.w = this._container.clientWidth;
-            this.h = this._container.clientHeight;
+            this._w = this._container.clientWidth;
+            this._h = this._container.clientHeight;
         }
 
         WorkContainer.prototype._create = function() {
@@ -62,7 +62,7 @@ require.def('antie/widgets/label/texttruncation/workcontainer',
          * @returns True if the text is overflowing the container.
          */
         WorkContainer.prototype.isOver = function() {
-            return this._measuringHorizontally ? this._container.clientWidth > this.w : this._container.clientHeight > this.h;
+            return this._measuringHorizontally ? this._container.clientWidth > this._w : this._container.clientHeight > this._h;
         };
         return WorkContainer;
     }

--- a/static/script/widgets/label/texttruncation/workcontainer.js
+++ b/static/script/widgets/label/texttruncation/workcontainer.js
@@ -20,6 +20,7 @@ require.def('antie/widgets/label/texttruncation/workcontainer',
             this._measuringHorizontally = measuringHorizontally;
             this._container = null;
             this._txtTruncationElNode = null;
+            this._currentTxtNodeTxt = "";
             this._create();
             // the width and height of the box that the text should be truncated to fit into.
             // use the container (which has width auto and height 100%) clientWidth and clientHeight to get this value, not the parent el, because this takes into consideration any padding on the parent el
@@ -50,18 +51,16 @@ require.def('antie/widgets/label/texttruncation/workcontainer',
         };
 
         /**
-         * Set the text on the text node in the container.
-         * @param {String} [txt] The text to place in the text node.
-         */
-        WorkContainer.prototype.setTxt = function(txt) {
-            this._txtTruncationElNode.nodeValue = txt;
-        };
-
-        /**
-         * Determine if the current text in the text node either overflows the width if measuring horizontally, or height otherwise.
+         * Determine if some text overflows the width if measuring horizontally, or height otherwise.
+         * @param {String} [txt] The text to measure.
          * @returns True if the text is overflowing the container.
          */
-        WorkContainer.prototype.isOver = function() {
+        WorkContainer.prototype.isOver = function(txt) {
+            // make sure only update the dom if necessary
+            if (this._currentTxtNodeTxt !== txt) {
+                this._currentTxtNodeTxt = txt;
+                this._txtTruncationElNode.nodeValue = txt;
+            }
             return this._measuringHorizontally ? this._container.clientWidth > this._w : this._container.clientHeight > this._h;
         };
         return WorkContainer;

--- a/static/script/widgets/label/texttruncation/workcontainer.js
+++ b/static/script/widgets/label/texttruncation/workcontainer.js
@@ -77,7 +77,7 @@ require.def('antie/widgets/label/texttruncation/workcontainer',
                     this._txtTruncationElNode.nodeValue = txt;
                 }
                 var size = this._device.getElementSize(this._container);
-                return this._measuringHorizontally ? size.width > this._w : size.height > this._h;
+                return this._measuringHorizontally ? size.width >= this._w : size.height >= this._h;
             },
 
             /**

--- a/static/script/widgets/label/texttruncation/workcontainer.js
+++ b/static/script/widgets/label/texttruncation/workcontainer.js
@@ -62,10 +62,12 @@ require.def('antie/widgets/label/texttruncation/workcontainer',
                 // the width and height of the box that the text should be truncated to fit into.
                 // use the container (which has width auto and height 100%) to get these values, not the parent el, because this takes into consideration any padding on the parent el
                 // clientWidth and clientHeight includes padding (but not border or margin), but we know that container will have padding of 0 and will sit within parents padding :)
+                this._cssManager = new CssManager(this._parentEl, this._measuringHorizontally);
+                this._cssManager.configureForMeasuring();
                 var size = this._device.getElementSize(this._container);
                 this._w = size.width;
                 this._h = size.height;
-                this._cssManager = new CssManager(this._parentEl, this._measuringHorizontally);
+                this._cssManager.configureForAlgorithm();
             },
 
             _createContainer: function() {

--- a/static/script/widgets/label/texttruncation/workcontainer.js
+++ b/static/script/widgets/label/texttruncation/workcontainer.js
@@ -33,6 +33,8 @@ require.def('antie/widgets/label/texttruncation/workcontainer',
         }
 
         WorkContainer.prototype._create = function() {
+
+            // TODO: try and use framework
             this._container = document.createElement("div");
             this._container.style.display = "block";
             this._container.style.margin = "0";
@@ -84,7 +86,7 @@ require.def('antie/widgets/label/texttruncation/workcontainer',
                 txtWorkingOn = txt.slice(0, position) + txtEnd;
             }
             return position;
-        }
+        };
         return WorkContainer;
     }
 );

--- a/static/script/widgets/label/texttruncation/workcontainer.js
+++ b/static/script/widgets/label/texttruncation/workcontainer.js
@@ -104,7 +104,7 @@ require.def('antie/widgets/label/texttruncation/workcontainer',
                     this._txtTruncationElNode.nodeValue = txt;
                 }
                 var size = this._device.getElementSize(this._container);
-                // TODO: this is failing the test. Should be > that this works because of rounding inconsistencies.
+                // getElementSize() returns a measurement rounded to an integer so >= instead of > compensates for this
                 return this._measuringHorizontally ? size.width >= this._w : size.height >= this._h;
             },
 

--- a/static/script/widgets/label/texttruncation/workcontainer.js
+++ b/static/script/widgets/label/texttruncation/workcontainer.js
@@ -29,10 +29,10 @@ require.def('antie/widgets/label/texttruncation/workcontainer',
                 this._device = device;
                 this._parentEl = parentEl;
                 this._measuringHorizontally = measuringHorizontally;
-                this._container = null;
-                this._txtTruncationElNode = null;
-                this._currentTxtNodeTxt = "";
-                this._create();
+                this._container = this._createContainer();
+                this._txtTruncationElNode = this._createTxtTruncationElNode();
+                this._container.appendChild(this._txtTruncationElNode);
+                this._parentEl.appendChild(this._container);
                 // the width and height of the box that the text should be truncated to fit into.
                 // use the container (which has width auto and height 100%) to get these values, not the parent el, because this takes into consideration any padding on the parent el
                 // clientWidth and clientHeight includes padding (but not border or margin), but we know that container will have padding of 0 and will sit within parents padding :)
@@ -42,18 +42,20 @@ require.def('antie/widgets/label/texttruncation/workcontainer',
                 this._cssManager = new CssManager(this._parentEl, this._measuringHorizontally);
             },
 
-            _create: function() {
-                this._container = document.createElement("div");
-                this._container.style.display = "block";
-                this._container.style.margin = "0";
-                this._container.style.padding = "0";
-                this._container.style.width = "auto";
-                this._container.style.height = "100%";
-                this._container.style.overflow = "hidden";
-                this._container.style.visibility = "hidden";
-                this._txtTruncationElNode = document.createTextNode("");
-                this._container.appendChild(this._txtTruncationElNode);
-                this._parentEl.appendChild(this._container);
+            _createContainer: function() {
+                var container = document.createElement("div");
+                container.style.display = "block";
+                container.style.margin = "0";
+                container.style.padding = "0";
+                container.style.width = "auto";
+                container.style.height = "100%";
+                container.style.overflow = "hidden";
+                container.style.visibility = "hidden";
+                return container;
+            },
+
+            _createTxtTruncationElNode: function() {
+                return document.createTextNode("");
             },
 
             /**

--- a/static/script/widgets/label/texttruncation/workcontainer.js
+++ b/static/script/widgets/label/texttruncation/workcontainer.js
@@ -1,0 +1,53 @@
+require.def('antie/widgets/label/texttruncation/workcontainer',
+    [
+    ],
+    function () {
+        "use strict";
+
+        // put the text node that we will be working on inside a container in the target el.
+        // the container will be set to fill the main element
+        // this means we can set the visibility to hidden and overflow to hidden on this container to make sure any temporary work isn't visible and doesn't effect anything else on the page.
+        // the text node must be created under the el in the dom hireachy so that it inherits all the correct css styles.
+        function WorkContainer(parentEl, measuringHorizontally) {
+            this._parentEl = parentEl;
+            this._measuringHorizontally = measuringHorizontally;
+            this._container = null;
+            this._txtTruncationElNode = null;
+            this._create();
+            // the width and height of the box that the text should be truncated to fit into.
+            // use the container (which has width auto and height 100%) clientWidth and clientHeight to get this value, not the parent el, because this takes into consideration any padding on the parent el
+            // clientWidth and clientHeight includes padding (but not border or margin), but we know that container will have padding of 0 and will sit within parents padding :)
+            this.w = this._container.clientWidth;
+            this.h = this._container.clientHeight;
+        }
+
+        WorkContainer.prototype._create = function() {
+            this._container = document.createElement("div");
+            this._container.style.display = "block";
+            this._container.style.margin = "0";
+            this._container.style.padding = "0";
+            this._container.style.width = "auto";
+            this._container.style.height = "100%";
+            this._container.style.overflow = "hidden";
+            this._container.style.visibility = "hidden";
+            this._txtTruncationElNode = document.createTextNode("");
+            this._container.appendChild(this._txtTruncationElNode);
+            this._parentEl.appendChild(this._container);
+        };
+
+        WorkContainer.prototype.destroy = function() {
+            this._container.removeChild(this._txtTruncationElNode); //TODO: check this is necessary
+            this._parentEl.removeChild(this._container);
+        };
+
+        WorkContainer.prototype.setTxt = function(txt) {
+            this._txtTruncationElNode.nodeValue = txt;
+        };
+
+        WorkContainer.prototype.isOver = function() {
+            return this._measuringHorizontally ? this._container.clientWidth > this.w : this._container.clientHeight > this.h;
+        };
+
+        return WorkContainer;
+    }
+);

--- a/static/script/widgets/label/texttruncation/workcontainer.js
+++ b/static/script/widgets/label/texttruncation/workcontainer.js
@@ -1,6 +1,9 @@
 require.def('antie/widgets/label/texttruncation/workcontainer',
-    ['antie/widgets/label/texttruncation/cssmanager'],
-    function (CssManager) {
+    [
+        'antie/widgets/label/texttruncation/cssmanager',
+        'antie/widgets/label/texttruncation/positiongenerator'
+    ],
+    function (CssManager, PositionGenerator) {
         "use strict";
 
         /**
@@ -64,6 +67,24 @@ require.def('antie/widgets/label/texttruncation/workcontainer',
             }
             return this._measuringHorizontally ? this._container.clientWidth > this._w : this._container.clientHeight > this._h;
         };
+
+        /**
+         * Perform a binary chop to calculate the number of characters that fit into this WorkContainer.
+         * @param {String} txt The source string to work on.
+         * @param {String} txtEnd The text that would be added after the truncated text. E.g "...".
+         *                        The length of this is not included in the returned value.
+         * @returns The number of characters that fit in this WorkContainer.
+         */
+        WorkContainer.prototype.getNumCharactersThatFit = function(txt, txtEnd) {
+            var positionGenerator = new PositionGenerator(txt.length);
+            var position = txt.length;
+            var txtWorkingOn = txt;
+            while(positionGenerator.hasNext(this.isOver(txtWorkingOn))) {
+                position = positionGenerator.next(this.isOver(txtWorkingOn));
+                txtWorkingOn = txt.slice(0, position) + txtEnd;
+            }
+            return position;
+        }
         return WorkContainer;
     }
 );

--- a/static/script/widgets/label/texttruncation/workcontainer.js
+++ b/static/script/widgets/label/texttruncation/workcontainer.js
@@ -1,9 +1,10 @@
 require.def('antie/widgets/label/texttruncation/workcontainer',
     [
+        "antie/class",
         'antie/widgets/label/texttruncation/cssmanager',
         'antie/widgets/label/texttruncation/positiongenerator'
     ],
-    function (CssManager, PositionGenerator) {
+    function (Class, CssManager, PositionGenerator) {
         "use strict";
 
         /**
@@ -13,80 +14,91 @@ require.def('antie/widgets/label/texttruncation/workcontainer',
          * Because the text node is being created under the parent element in the dom hireachy so that it inherits all of the correct css styles.
          * @name antie.widgets.label.texttruncation.workcontainer
          * @class
+         * @param {antie.devices.Device} [device] The antie.devices.Device object currently running this application.
          * @param {DOMElement} [parentEl] The DOMElement that should contain this.
          * @param {Boolean} [measuringHorizontally] True if this container is being used to compare the width of the text to the width of the container.
          *                                          False if the container is being used to compare the height of the text to the height of the container.
          */
-        function WorkContainer(parentEl, measuringHorizontally) {
-            this._parentEl = parentEl;
-            this._measuringHorizontally = measuringHorizontally;
-            this._container = null;
-            this._txtTruncationElNode = null;
-            this._currentTxtNodeTxt = "";
-            this._create();
-            // the width and height of the box that the text should be truncated to fit into.
-            // use the container (which has width auto and height 100%) clientWidth and clientHeight to get this value, not the parent el, because this takes into consideration any padding on the parent el
-            // clientWidth and clientHeight includes padding (but not border or margin), but we know that container will have padding of 0 and will sit within parents padding :)
-            this._w = this._container.clientWidth;
-            this._h = this._container.clientHeight;
-            this._cssManager = new CssManager(this._parentEl, this._measuringHorizontally);
-        }
+        var WorkContainer = Class.extend(/** @lends antie.widgets.label.texttruncation.workcontainer.prototype */ {
 
-        WorkContainer.prototype._create = function() {
+            /**
+             * @constructor
+             * @ignore
+             */
+            init: function(device, parentEl, measuringHorizontally) {
+                this._device = device;
+                this._parentEl = parentEl;
+                this._measuringHorizontally = measuringHorizontally;
+                this._container = null;
+                this._txtTruncationElNode = null;
+                this._currentTxtNodeTxt = "";
+                this._create();
+                // the width and height of the box that the text should be truncated to fit into.
+                // use the container (which has width auto and height 100%) to get these values, not the parent el, because this takes into consideration any padding on the parent el
+                // clientWidth and clientHeight includes padding (but not border or margin), but we know that container will have padding of 0 and will sit within parents padding :)
+                var size = this._device.getElementSize(this._container);
+                this._w = size.width;
+                this._h = size.height;
+                this._cssManager = new CssManager(this._parentEl, this._measuringHorizontally);
+            },
 
-            // TODO: try and use framework
-            this._container = document.createElement("div");
-            this._container.style.display = "block";
-            this._container.style.margin = "0";
-            this._container.style.padding = "0";
-            this._container.style.width = "auto";
-            this._container.style.height = "100%";
-            this._container.style.overflow = "hidden";
-            this._container.style.visibility = "hidden";
-            this._txtTruncationElNode = document.createTextNode("");
-            this._container.appendChild(this._txtTruncationElNode);
-            this._parentEl.appendChild(this._container);
-        };
+            _create: function() {
+                // TODO: try and use framework
+                this._container = document.createElement("div");
+                this._container.style.display = "block";
+                this._container.style.margin = "0";
+                this._container.style.padding = "0";
+                this._container.style.width = "auto";
+                this._container.style.height = "100%";
+                this._container.style.overflow = "hidden";
+                this._container.style.visibility = "hidden";
+                this._txtTruncationElNode = document.createTextNode("");
+                this._container.appendChild(this._txtTruncationElNode);
+                this._parentEl.appendChild(this._container);
+            },
 
-        /**
-         * Destroy the container and the text node contained in it.
-         */
-        WorkContainer.prototype.destroy = function() {
-            this._parentEl.removeChild(this._container);
-            this._cssManager.restore();
-        };
+            /**
+             * Destroy the container and the text node contained in it.
+             */
+            destroy: function() {
+                this._parentEl.removeChild(this._container);
+                this._cssManager.restore();
+            },
 
-        /**
-         * Determine if some text overflows the width if measuring horizontally, or height otherwise.
-         * @param {String} [txt] The text to measure.
-         * @returns True if the text is overflowing the container.
-         */
-        WorkContainer.prototype.isOver = function(txt) {
-            // make sure only update the dom if necessary
-            if (this._currentTxtNodeTxt !== txt) {
-                this._currentTxtNodeTxt = txt;
-                this._txtTruncationElNode.nodeValue = txt;
+            /**
+             * Determine if some text overflows the width if measuring horizontally, or height otherwise.
+             * @param {String} [txt] The text to measure.
+             * @returns True if the text is overflowing the container.
+             */
+            isOver: function(txt) {
+                // make sure only update the dom if necessary
+                if (this._currentTxtNodeTxt !== txt) {
+                    this._currentTxtNodeTxt = txt;
+                    this._txtTruncationElNode.nodeValue = txt;
+                }
+                var size = this._device.getElementSize(this._container);
+                return this._measuringHorizontally ? size.width > this._w : size.height > this._h;
+            },
+
+            /**
+             * Perform a binary chop to calculate the number of characters that fit into this WorkContainer.
+             * @param {String} txt The source string to work on.
+             * @param {String} txtEnd The text that would be added after the truncated text. E.g "...".
+             *                        The length of this is not included in the returned value.
+             * @returns The number of characters that fit in this WorkContainer.
+             */
+            getNumCharactersThatFit: function(txt, txtEnd) {
+                var positionGenerator = new PositionGenerator(txt.length);
+                var position = txt.length;
+                var txtWorkingOn = txt;
+                while(positionGenerator.hasNext(this.isOver(txtWorkingOn))) {
+                    position = positionGenerator.next(this.isOver(txtWorkingOn));
+                    txtWorkingOn = txt.slice(0, position) + txtEnd;
+                }
+                return position;
             }
-            return this._measuringHorizontally ? this._container.clientWidth > this._w : this._container.clientHeight > this._h;
-        };
 
-        /**
-         * Perform a binary chop to calculate the number of characters that fit into this WorkContainer.
-         * @param {String} txt The source string to work on.
-         * @param {String} txtEnd The text that would be added after the truncated text. E.g "...".
-         *                        The length of this is not included in the returned value.
-         * @returns The number of characters that fit in this WorkContainer.
-         */
-        WorkContainer.prototype.getNumCharactersThatFit = function(txt, txtEnd) {
-            var positionGenerator = new PositionGenerator(txt.length);
-            var position = txt.length;
-            var txtWorkingOn = txt;
-            while(positionGenerator.hasNext(this.isOver(txtWorkingOn))) {
-                position = positionGenerator.next(this.isOver(txtWorkingOn));
-                txtWorkingOn = txt.slice(0, position) + txtEnd;
-            }
-            return position;
-        };
+        });
         return WorkContainer;
     }
 );

--- a/static/script/widgets/label/texttruncation/workcontainer.js
+++ b/static/script/widgets/label/texttruncation/workcontainer.js
@@ -15,9 +15,9 @@ require.def('antie/widgets/label/texttruncation/workcontainer',
          * @name antie.widgets.label.texttruncation.WorkContainer
          * @class
          * @param {antie.devices.Device} [device] The antie.devices.Device object currently running this application.
-         * @param {DOMElement} [parentEl] The DOMElement that should contain this.
-         * @param {Boolean} [measuringHorizontally] True if this container is being used to compare the width of the text to the width of the container.
-         *                                          False if the container is being used to compare the height of the text to the height of the container.
+         * @param {DOMElement} parentEl The DOMElement that should contain this.
+         * @param {Boolean} measuringHorizontally True if this container is being used to compare the width of the text to the width of the container.
+         *                                        False if the container is being used to compare the height of the text to the height of the container.
          */
          var WorkContainer = Class.extend(/** @lends antie.widgets.label.texttruncation.workcontainer.prototype */ {
 
@@ -67,7 +67,7 @@ require.def('antie/widgets/label/texttruncation/workcontainer',
 
             /**
              * Determine if some text overflows the width if measuring horizontally, or height otherwise.
-             * @param {String} [txt] The text to measure.
+             * @param {String} txt The text to measure.
              * @returns True if the text is overflowing the container.
              */
             isOver: function(txt) {

--- a/static/script/widgets/label/texttruncation/workcontainer.js
+++ b/static/script/widgets/label/texttruncation/workcontainer.js
@@ -104,6 +104,7 @@ require.def('antie/widgets/label/texttruncation/workcontainer',
                     this._txtTruncationElNode.nodeValue = txt;
                 }
                 var size = this._device.getElementSize(this._container);
+                // TODO: this is failing the test. Should be > that this works because of rounding inconsistencies.
                 return this._measuringHorizontally ? size.width >= this._w : size.height >= this._h;
             },
 

--- a/static/script/widgets/label/texttruncation/workcontainer.js
+++ b/static/script/widgets/label/texttruncation/workcontainer.js
@@ -107,7 +107,9 @@ require.def('antie/widgets/label/texttruncation/workcontainer',
                 }
                 var size = this._device.getElementSize(this._container);
                 // getElementSize() returns a measurement rounded to an integer so >= instead of > compensates for this
-                return this._measuringHorizontally ? size.width >= this._w : size.height >= this._h;
+                // don't need to worry about this for height, because the effect of it being a pixel over for height doesn't have a major effect on anything.
+                // if the width was out by a pixel, this could result in the algorithm detecting where a line would wrap later than it would, which could result in an extra line.
+                return this._measuringHorizontally ? size.width >= this._w : size.height > this._h;
             },
 
             /**

--- a/static/script/widgets/label/texttruncation/workcontainer.js
+++ b/static/script/widgets/label/texttruncation/workcontainer.js
@@ -1,7 +1,6 @@
 require.def('antie/widgets/label/texttruncation/workcontainer',
-    [
-    ],
-    function () {
+    ['antie/widgets/label/texttruncation/cssmanager'],
+    function (CssManager) {
         "use strict";
 
         /**
@@ -27,6 +26,7 @@ require.def('antie/widgets/label/texttruncation/workcontainer',
             // clientWidth and clientHeight includes padding (but not border or margin), but we know that container will have padding of 0 and will sit within parents padding :)
             this._w = this._container.clientWidth;
             this._h = this._container.clientHeight;
+            this._cssManager = new CssManager(this._parentEl, measuringHorizontally);
         }
 
         WorkContainer.prototype._create = function() {
@@ -48,6 +48,7 @@ require.def('antie/widgets/label/texttruncation/workcontainer',
          */
         WorkContainer.prototype.destroy = function() {
             this._parentEl.removeChild(this._container);
+            this._cssManager.restore();
         };
 
         /**

--- a/static/script/widgets/label/texttruncation/workcontainer.js
+++ b/static/script/widgets/label/texttruncation/workcontainer.js
@@ -26,7 +26,7 @@ require.def('antie/widgets/label/texttruncation/workcontainer',
             // clientWidth and clientHeight includes padding (but not border or margin), but we know that container will have padding of 0 and will sit within parents padding :)
             this._w = this._container.clientWidth;
             this._h = this._container.clientHeight;
-            this._cssManager = new CssManager(this._parentEl, measuringHorizontally);
+            this._cssManager = new CssManager(this._parentEl, this._measuringHorizontally);
         }
 
         WorkContainer.prototype._create = function() {

--- a/static/script/widgets/label/texttruncation/workcontainer.js
+++ b/static/script/widgets/label/texttruncation/workcontainer.js
@@ -31,6 +31,8 @@ require.def('antie/widgets/label/texttruncation/workcontainer',
                 this._measuringHorizontally = measuringHorizontally;
                 this._container = this._createContainer();
                 this._txtTruncationElNode = this._createTxtTruncationElNode();
+                // clear any text that's currently there
+                this._parentEl.innerHTML = "";
                 this._container.appendChild(this._txtTruncationElNode);
                 this._parentEl.appendChild(this._container);
                 // the width and height of the box that the text should be truncated to fit into.

--- a/static/script/widgets/label/texttruncation/workcontainer.js
+++ b/static/script/widgets/label/texttruncation/workcontainer.js
@@ -46,7 +46,6 @@ require.def('antie/widgets/label/texttruncation/workcontainer',
          * Destroy the container and the text node contained in it.
          */
         WorkContainer.prototype.destroy = function() {
-            this._container.removeChild(this._txtTruncationElNode); //TODO: check this is necessary
             this._parentEl.removeChild(this._container);
         };
 

--- a/static/script/widgets/label/texttruncation/workcontainer.js
+++ b/static/script/widgets/label/texttruncation/workcontainer.js
@@ -43,7 +43,6 @@ require.def('antie/widgets/label/texttruncation/workcontainer',
             },
 
             _create: function() {
-                // TODO: try and use framework
                 this._container = document.createElement("div");
                 this._container.style.display = "block";
                 this._container.style.margin = "0";


### PR DESCRIPTION
This is a new implementation of the render function for the Label widget to manage text truncation if enabled. Text truncation is enabled the same way as before with the setTruncationMode function and should be backward compatible with anything already using it, except for the fact that the setWidth function has been removed as its's only use was for the old text truncation method, and is no longer necessary for the new one.

ADVANTAGES
- You no longer need to specify the width with setWidth, it uses the width and height that the widget will be styled with/inherit when it is added to the dom.
- Its default operation will be to fit the truncate the text to fit in the widget's width and height. You don't have to tell it how many lines that would be.
- You can tell it to truncate after a certain number of lines by using the setMaximumLines function. A value of 0 means fit the container.
- Because it calculates the amount of text that will fit in place, it will work with whatever styles are inherited at where the widget is placed. I.e. the font size could be set a few steps up in the dom hierarchy and this will be taken into consideration.
- Should be recalculated if the text updated.

DISADVANTAGES
- If the container that the text is in changes size the text will not be re-truncated and adapt to this. The current system doesn't do this either.
- There is a bit of processing that needs to be done when the widget is added to the visible DOM before the final text is added and appears, but this still seems to be pretty instant, only happens if text truncation is turned on, and the old system also had this. I haven't measured times precisely though so don't know if the old system was quicker. The text is not visible whilst this is done and it shouldn't effect anything else on the page.
- At the moment this uses a callback attached to the Label widget. This might not be the best way of doing this. Maybe an event instead?

I will open a ticket on JIRA for this after the request has gone through.