### PR TITLE
Set removal of child nodes in clearElement.

### DIFF
--- a/static/script/devices/browserdevice.js
+++ b/static/script/devices/browserdevice.js
@@ -294,7 +294,9 @@ require.def("antie/devices/browserdevice",
              * @param {Element} el The element you are removing the content from.
              */
             clearElement: function(el) {
-                el.innerHTML = "";
+                for (var i = el.childNodes.length - 1; i >= 0; i--) {
+                    el.removeChild(el.childNodes[i]);
+                };
             },
             /**
              * Sets the classes of an element.

--- a/static/script/devices/browserdevice.js
+++ b/static/script/devices/browserdevice.js
@@ -296,7 +296,7 @@ require.def("antie/devices/browserdevice",
             clearElement: function(el) {
                 for (var i = el.childNodes.length - 1; i >= 0; i--) {
                     el.removeChild(el.childNodes[i]);
-                };
+                }
             },
             /**
              * Sets the classes of an element.

--- a/static/script/devices/browserdevice.js
+++ b/static/script/devices/browserdevice.js
@@ -425,6 +425,10 @@ require.def("antie/devices/browserdevice",
              * @param {String} content The new content for the element.
              */
             setElementContent: function(el, content) {
+                if (content === "") {
+                    this.clearElement(el);
+                    return;
+                }
                 el.innerHTML = content;
             },
             /**


### PR DESCRIPTION
This change to clear element ensures that previously attached child elements are still held in memory in IE based browsers.

In the previous implementation IE browsers would also clear child elements from memory.