### PR TITLE
Ensure GitHub ribbon in the TAL documentation does not display on mobile

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -35,7 +35,7 @@
 
     {% include navbar.html %}
 
-    <a href="https://github.com/fmtvp/tal"><img style="position: absolute; top: 0; right: 0; border: 0; z-index: 9999" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" alt="Fork me on GitHub"></a>
+    <a class="hidden-phone" href="https://github.com/fmtvp/tal"><img style="position: absolute; top: 0; right: 0; border: 0; z-index: 9999" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" alt="Fork me on GitHub"></a>
     
     <div class="container">
             

--- a/_layouts/faq.html
+++ b/_layouts/faq.html
@@ -59,7 +59,7 @@
 
     {% include navbar.html %}
 
-    <a href="https://github.com/fmtvp/tal"><img style="position: absolute; top: 0; right: 0; border: 0; z-index: 9999" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" alt="Fork me on GitHub"></a>
+    <a class="hidden-phone" href="https://github.com/fmtvp/tal"><img style="position: absolute; top: 0; right: 0; border: 0; z-index: 9999" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" alt="Fork me on GitHub"></a>
     
     <div class="container">
             

--- a/_layouts/landing.html
+++ b/_layouts/landing.html
@@ -41,7 +41,7 @@
   <body>
 
     {% include navbar.html %}
-    <a href="https://github.com/fmtvp/tal"><img style="position: absolute; top: 0; right: 0; border: 0; z-index: 9999" src="https://s3.amazonaws.com/github/ribbons/forkme_right_white_ffffff.png" alt="Fork me on GitHub"></a>
+    <a class="hidden-phone" href="https://github.com/fmtvp/tal"><img style="position: absolute; top: 0; right: 0; border: 0; z-index: 9999" src="https://s3.amazonaws.com/github/ribbons/forkme_right_white_ffffff.png" alt="Fork me on GitHub"></a>
     
     <div>
             

--- a/_layouts/widgets.html
+++ b/_layouts/widgets.html
@@ -37,7 +37,7 @@
   <body data-spy="scroll" data-target="#sidenav">
 
     {% include navbar.html %}
-    <a href="https://github.com/fmtvp/tal"><img style="position: absolute; top: 0; right: 0; border: 0; z-index: 9999" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" alt="Fork me on GitHub"></a>
+    <a class="hidden-phone" href="https://github.com/fmtvp/tal"><img style="position: absolute; top: 0; right: 0; border: 0; z-index: 9999" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" alt="Fork me on GitHub"></a>
     
     <div class="container-fluid">
             


### PR DESCRIPTION
I noticed when reading the docs on mobile, the GitHub ribbon in the top right of the page got in the way of selecting menu items, which meant that you can't access some pages - please see example below. Because the selectable area of the ribbon is a square, it means that it sites above a couple of the menu links on the right.

This commit adds the `hidden-phone` CSS class to the ribbon so that it doesn't display on mobile devices.

![example-of-github-ribbon-on-tal-site](https://cloud.githubusercontent.com/assets/1943532/5977578/1956d8f6-a891-11e4-8dcb-86c7fcba1815.jpg)
