### PR TITLE
Docs: Note about getting a reference to the device abstraction layer

### DIFF
--- a/faq.md
+++ b/faq.md
@@ -108,6 +108,5 @@ achieve the common goal of media playback.
 **Answer:** You will see ANTIE throughout the code.  It's the just the original code
 name for the project, before it became TAL.
 
-
 ### **Question:** I have a query, who can I send it to?  
 **Answer:** Please see the [contributing](other/contributing.html) page to see how to get in touch. Alternatively you can ask questions on the [TAL Google Group](https://groups.google.com/forum/#!forum/talopensource).

--- a/faq.md
+++ b/faq.md
@@ -87,6 +87,9 @@ parameter, but its up to you how you do it.
 ### **Question:** What gets specified in a device configuration file?  
 **Answer:** See the [device configuration](overview/device-configuration.html) page for specific details.
 
+### **Question** How do I get a reference the device abstraction layer in the code?
+**Answer** To get a reference to the device, include RunTime context in your require.js dependancies (`"antie/runtimecontext"`), then in your code get a reference with `var device = RuntimeContext.getDevice();`.
+
 ### **Question:** Does TAL support any DRM solutions?  
 **Answer:** Currently it doesn't, but the TAL project has talked to several DRM providers who are interested 
 in looking at integrating their solutions with TAL.
@@ -104,6 +107,7 @@ achieve the common goal of media playback.
 ### **Question:** What is ANTIE?
 **Answer:** You will see ANTIE throughout the code.  It's the just the original code
 name for the project, before it became TAL.
+
 
 ### **Question:** I have a query, who can I send it to?  
 **Answer:** Please see the [contributing](other/contributing.html) page to see how to get in touch. Alternatively you can ask questions on the [TAL Google Group](https://groups.google.com/forum/#!forum/talopensource).

--- a/other/networking.md
+++ b/other/networking.md
@@ -8,6 +8,16 @@ title: Networking
 
 Same origin GET requests (where the resource being fetched is on the same host as the application) are straightforward. Due to [browser security](http://en.wikipedia.org/wiki/Same_origin_policy), cross-domain GETs and POSTs place certain requirements on the backend and on the device.
 
+
+<div class="alert alert-info">
+        <p><strong>Note</strong> you will need to obtain a reference to the device abstraction layer in order to use the networking methods:</p>
+        <ol>
+            <li>Include the RunTime context in your require.js dependancies: <code>"antie/runtimecontext"</code></li>
+            <li>Get a reference to the device: <code>device = RuntimeContext.getDevice();</code></li>
+        </ol>
+</div>
+
+
 ## Performing a Same Origin GET Request
 
 To perform a GET request to the same origin as the application, obtain a reference to the device, then use the `loadUrl()` function:

--- a/other/networking.md
+++ b/other/networking.md
@@ -8,10 +8,9 @@ title: Networking
 
 Same origin GET requests (where the resource being fetched is on the same host as the application) are straightforward. Due to [browser security](http://en.wikipedia.org/wiki/Same_origin_policy), cross-domain GETs and POSTs place certain requirements on the backend and on the device.
 
-
 ## Performing a Same Origin GET Request
 
-To perform a GET request to the same origin as the application, obtain a reference to the device, then use the `loadUrl()` function:
+To perform a GET request to the same origin as the application, [obtain a reference to the device](/tal/faq.html#question-how-do-i-get-a-refernce-the-device-abstraction-layer-in-the-code), then use the `loadUrl()` function:
 {% highlight javascript %}
 device.loadURL(url, {
         onLoad: function(responseText) {

--- a/other/networking.md
+++ b/other/networking.md
@@ -9,15 +9,6 @@ title: Networking
 Same origin GET requests (where the resource being fetched is on the same host as the application) are straightforward. Due to [browser security](http://en.wikipedia.org/wiki/Same_origin_policy), cross-domain GETs and POSTs place certain requirements on the backend and on the device.
 
 
-<div class="alert alert-info">
-        <p><strong>Note</strong> you will need to obtain a reference to the device abstraction layer in order to use the networking methods:</p>
-        <ol>
-            <li>Include the RunTime context in your require.js dependancies: <code>"antie/runtimecontext"</code></li>
-            <li>Get a reference to the device: <code>device = RuntimeContext.getDevice();</code></li>
-        </ol>
-</div>
-
-
 ## Performing a Same Origin GET Request
 
 To perform a GET request to the same origin as the application, obtain a reference to the device, then use the `loadUrl()` function:

--- a/other/storage.md
+++ b/other/storage.md
@@ -6,6 +6,14 @@ title: Storage
 
 <p class="lead">The framework provides an abstracted notion of storage. Both session and persistent storage providers are available with a common API that allows you to maintain a key-object store.</p>
 
+<div class="alert alert-info">
+        <p><strong>Note</strong> you will need to obtain a reference to the device abstraction layer in order to use the networking methods:</p>
+        <ol>
+            <li>Include the RunTime context in your require.js dependancies: <code>"antie/runtimecontext"</code></li>
+            <li>Get a reference to the device: <code>device = RuntimeContext.getDevice();</code></li>
+        </ol>
+</div>
+
 ## Obtaining a Storage Provider
 
 You can obtain a storage provider via the device abstraction layer.

--- a/other/storage.md
+++ b/other/storage.md
@@ -6,19 +6,11 @@ title: Storage
 
 <p class="lead">The framework provides an abstracted notion of storage. Both session and persistent storage providers are available with a common API that allows you to maintain a key-object store.</p>
 
-<div class="alert alert-info">
-        <p><strong>Note</strong> you will need to obtain a reference to the device abstraction layer in order to use the networking methods:</p>
-        <ol>
-            <li>Include the RunTime context in your require.js dependancies: <code>"antie/runtimecontext"</code></li>
-            <li>Get a reference to the device: <code>device = RuntimeContext.getDevice();</code></li>
-        </ol>
-</div>
-
 ## Obtaining a Storage Provider
 
 You can obtain a storage provider via the device abstraction layer.
 
-To obtain a storage provider, call `device.getStorage(...)`, e.g, to obtain session storage, call:
+To obtain a storage provider, [get a reference to the device](/tal/faq.html#question-how-do-i-get-a-refernce-the-device-abstraction-layer-in-the-code) and then call `device.getStorage(...)`, e.g, to obtain session storage, call:
 {% highlight javascript %}
 var storage = device.getStorage(StorageProvider.STORAGE_TYPE_SESSION, namespace);
 {% endhighlight %}


### PR DESCRIPTION
One of the problems I had when understanding how to implement networking with TAL was that I didn't know how to obtain a reference to the device abstraction later. 

I've added a note in the networking and storage pages which I think would be really useful for new adopters.

Please let me know what you think.