### PR TITLE
Added explanation about setting active child key on keyboard

### DIFF
--- a/widgets/working-with-widgets.md
+++ b/widgets/working-with-widgets.md
@@ -189,13 +189,13 @@ See [scrubbar.js]({{site.baseurl}}/jsdoc/symbols/antie.widgets.ScrubBar.html) fo
 
 ## KeyBoard
 
-Versatile on-screen keyboard. To enable focus on the keyboard keys, you must first set the active child key, for example:
+Versatile on-screen keyboard, with keys laid out on a grid. Note that to enable focus on the keyboard keys, you must first set the active child key, for example:
 
 `myVirtualKeyBoard.setActiveChildKey('A')`
 
 ![Key Board]({{site.baseurl}}/img/widgets/keyboard.png)
 
-See [keyboard.js]({{site.baseurl}}/jsdoc/symbols/antie.widgets.Keyboard.html) for the javascript documentation.
+See [keyboard.js]({{site.baseurl}}/jsdoc/symbols/antie.widgets.Keyboard.html) for the Javascript documentation.
 
 ## TextPager
 

--- a/widgets/working-with-widgets.md
+++ b/widgets/working-with-widgets.md
@@ -189,7 +189,9 @@ See [scrubbar.js]({{site.baseurl}}/jsdoc/symbols/antie.widgets.ScrubBar.html) fo
 
 ## KeyBoard
 
-Versatile on-screen keyboard.
+Versatile on-screen keyboard. To enable focus on the keyboard keys, you must first set the active child key, for example:
+
+`myVirtualKeyBoard.setActiveChildKey('A')`
 
 ![Key Board]({{site.baseurl}}/img/widgets/keyboard.png)
 


### PR DESCRIPTION
When leaning how to use the virtual keyboard, we couldn't get it to focus. We found that by setting the active child key on the board, we were then able to do this.

I added a quick note about it in the widget documentation.