### PR TITLE
Loadedmetadata workaround

### DIFF
--- a/static/script-tests/tests/devices/mediaplayer/html5commontests.js
+++ b/static/script-tests/tests/devices/mediaplayer/html5commontests.js
@@ -54,7 +54,7 @@ window.commonTests.mediaPlayer.html5.mixinTests = function (testCase, mediaPlaye
             stubCreateElement(sandbox,application);
         },
         sendMetadata: function(mediaPlayer, currentTime, range) {
-            setMetaData(mediaPlayer, currentTime, range);
+            setMetadata(mediaPlayer, currentTime, range);
             mediaEventListeners.loadedmetadata();
         },
         finishBuffering: function(mediaPlayer) {
@@ -266,7 +266,7 @@ window.commonTests.mediaPlayer.html5.mixinTests = function (testCase, mediaPlaye
         stubCreateElementResults.video.currentTime = 0;
     };
 
-    var setMetaData = function (mediaPlayer, currentTime, range) {
+    var setMetadata = function (mediaPlayer, currentTime, range) {
         var mediaElements = [stubCreateElementResults.video, stubCreateElementResults.audio];
         for (var i = 0; i < mediaElements.length; i++) {
             var media = mediaElements[i];
@@ -1639,6 +1639,32 @@ window.commonTests.mediaPlayer.html5.mixinTests = function (testCase, mediaPlaye
             deviceMockingHooks.finishBuffering(this._mediaPlayer);
 
             assert(debugStub.withArgs("playFrom 50 clamped to 60 - seekable range is { start: 60, end: 100 }").calledOnce);
+        });
+    };
+
+    mixins.testPlayFromSetsCurrentTimeAfterFinishBufferingButNoMetadata = function(queue) {
+        expectAsserts(1);
+        runMediaPlayerTest(this, queue, function (MediaPlayer) {
+            this._mediaPlayer.setSource(MediaPlayer.TYPE.VIDEO, 'http://testurl/', 'video/mp4');
+            this._mediaPlayer.playFrom(50);
+            setMetadata(this._mediaPlayer, 0, { start: 0, end: 100 });
+            deviceMockingHooks.finishBuffering(this._mediaPlayer);
+
+            assertEquals(50, stubCreateElementResults.video.currentTime);
+        });
+    };
+
+    mixins.testExitBufferingSentinelPerformsDeferredSeekIfNoLoadedMetadataEvent = function(queue) {
+        expectAsserts(1);
+        runMediaPlayerTest(this, queue, function (MediaPlayer) {
+            this._mediaPlayer.setSource(MediaPlayer.TYPE.VIDEO, 'http://testurl/', 'video/mp4');
+            this._mediaPlayer.playFrom(50);
+            setMetadata(this._mediaPlayer, 0, { start: 0, end: 100 });
+
+            advancePlayTime(self);
+            fireSentinels(self);
+
+            assertEquals(50, stubCreateElementResults.video.currentTime);
         });
     };
 

--- a/static/script-tests/tests/devices/mediaplayer/html5commontests.js
+++ b/static/script-tests/tests/devices/mediaplayer/html5commontests.js
@@ -54,14 +54,7 @@ window.commonTests.mediaPlayer.html5.mixinTests = function (testCase, mediaPlaye
             stubCreateElement(sandbox,application);
         },
         sendMetadata: function(mediaPlayer, currentTime, range) {
-            var mediaElements = [stubCreateElementResults.video, stubCreateElementResults.audio];
-            for (var i = 0; i < mediaElements.length; i++) {
-                var media = mediaElements[i];
-                media.duration = range.end;
-                media.currentTime = currentTime;
-                media.seekable.start.returns(range.start);
-                media.seekable.end.returns(range.end);
-            }
+            setMetaData(mediaPlayer, currentTime, range);
             mediaEventListeners.loadedmetadata();
         },
         finishBuffering: function(mediaPlayer) {
@@ -271,6 +264,17 @@ window.commonTests.mediaPlayer.html5.mixinTests = function (testCase, mediaPlaye
 
     var setPlayTimeToZero = function (self) {
         stubCreateElementResults.video.currentTime = 0;
+    };
+
+    var setMetaData = function (mediaPlayer, currentTime, range) {
+        var mediaElements = [stubCreateElementResults.video, stubCreateElementResults.audio];
+        for (var i = 0; i < mediaElements.length; i++) {
+            var media = mediaElements[i];
+            media.duration = range.end;
+            media.currentTime = currentTime;
+            media.seekable.start.returns(range.start);
+            media.seekable.end.returns(range.end);
+        }
     };
 
 

--- a/static/script-tests/tests/devices/mediaplayer/html5commontests.js
+++ b/static/script-tests/tests/devices/mediaplayer/html5commontests.js
@@ -1668,6 +1668,20 @@ window.commonTests.mediaPlayer.html5.mixinTests = function (testCase, mediaPlaye
         });
     };
 
+    mixins.testPlayFromNearCurrentTimeWillNotCauseFinishBufferingToPerformSeekLater = function(queue) {
+        expectAsserts(1);
+        runMediaPlayerTest(this, queue, function (MediaPlayer) {
+            getToPlaying(this, MediaPlayer);
+            stubCreateElementResults.video.currentTime = 50;
+            this._mediaPlayer.playFrom(50.999);
+
+            stubCreateElementResults.video.currentTime = 70;
+            deviceMockingHooks.finishBuffering(this._mediaPlayer);
+
+            assertEquals(70, stubCreateElementResults.video.currentTime);
+        });
+    };
+
     // TODO: Remove references to 'self' that are unecessary due to the use of '.call' in runMediaPlayerTest
     // TODO: Consider whether the ordering of the pause and seek sentinels is important, and if not we should not assert the order in the tests.
 

--- a/static/script/devices/mediaplayer/html5.js
+++ b/static/script/devices/mediaplayer/html5.js
@@ -369,13 +369,11 @@ require.def(
             },
 
             _onMetadata: function() {
-                this._readyToPlayFrom = true;
-                if (this._waitingToPlayFrom()) {
-                    this._deferredPlayFrom();
-                }
+                this._metadataLoaded();
             },
 
             _exitBuffering: function () {
+                this._metadataLoaded();
                 if (this.getState() !== MediaPlayer.STATE.BUFFERING) {
                     return;
 
@@ -384,6 +382,13 @@ require.def(
 
                 } else {
                     this._toPlaying();
+                }
+            },
+            
+            _metadataLoaded: function () {
+                this._readyToPlayFrom = true;
+                if (this._waitingToPlayFrom()) {
+                    this._deferredPlayFrom();
                 }
             },
 

--- a/static/script/devices/mediaplayer/html5.js
+++ b/static/script/devices/mediaplayer/html5.js
@@ -124,6 +124,7 @@ require.def(
                         this._toBuffering();
                         this._targetSeekTime = this._getClampedTimeForPlayFrom(seconds);
                         if (this._isNearToCurrentTime(this._targetSeekTime)) {
+                            this._targetSeekTime = undefined;
                             this._toPlaying();
                         } else {
                             this._playFromIfReady();


### PR DESCRIPTION
For devices that do not send loadedmetadata event, we should perform the 'onMetadata' actions upon finish buffering.