### PR TITLE
Added note about obtaining the device in animation docs

### DIFF
--- a/widgets/animation.md
+++ b/widgets/animation.md
@@ -8,6 +8,8 @@ title: Animation
 
 These methods are primarily intended for widget developers.
 
+Note that to use the animations methods you will first need to [obtain a reference to the device](/tal/faq.html#question-how-do-i-get-a-reference-the-device-abstraction-layer-in-the-code).
+
 ## Animation methods
 
 The following methods control animation:


### PR DESCRIPTION
This adds a note to the user about how to get a reference for the device, before they can use the animation methods.