### PR TITLE
Remove redundant 'extension point' test from html5commontests

### DIFF
--- a/static/script-tests/tests/devices/mediaplayer/html5commontests.js
+++ b/static/script-tests/tests/devices/mediaplayer/html5commontests.js
@@ -385,17 +385,6 @@ window.commonTests.mediaPlayer.html5.mixinTests = function (testCase, mediaPlaye
         });
     };
 
-    mixins.testSetSourceUsesGenerateSourceElementExtensionPoint = function(queue) {
-        expectAsserts(2);
-        var self = this;
-        runMediaPlayerTest(this, queue, function (MediaPlayer) {
-            self.sandbox.spy(self._mediaPlayer, "_generateSourceElement");
-            assert(self._mediaPlayer._generateSourceElement.notCalled);
-            self._mediaPlayer.setSource(MediaPlayer.TYPE.VIDEO, 'http://testurl/', 'video/mp4');
-            assert(self._mediaPlayer._generateSourceElement.calledWith('http://testurl/', 'video/mp4'));
-        });
-    };
-
     mixins.testIfDurationAndSeekableRangeIsMissingGetSeekableRangeReturnsUndefinedAndLogsAWarning = function(queue) {
         expectAsserts(2);
         var self = this;


### PR DESCRIPTION
Now that the html5untyped submodifier has been merged into this repository, there's no need to test explicitly that the extension point it needs is available.