### PR TITLE
Ensure test passes on both Chrome and PhantomJS

### DIFF
--- a/static/script-tests/tests/devices/mediaplayer/html5untyped.js
+++ b/static/script-tests/tests/devices/mediaplayer/html5untyped.js
@@ -51,7 +51,7 @@
             var childElement = self.stubCreateElementResults.video.firstChild;
             assertEquals('source', childElement.nodeName.toLowerCase());
             assertEquals('http://testurl/', childElement.src);
-            assertEquals('', childElement.type);
+            assertFalse(!!childElement.type);
         });
     };
 


### PR DESCRIPTION
Chrome sets the 'type' attribute on the source element to an empty string, PhantomJS leaves it undefined.