### PR TITLE
Pause and complete sentinels now use time changed rather than time advanced

### DIFF
--- a/static/script-tests/tests/devices/mediaplayer/html5commontests.js
+++ b/static/script-tests/tests/devices/mediaplayer/html5commontests.js
@@ -1159,6 +1159,25 @@ window.commonTests.mediaPlayer.html5.mixinTests = function (testCase, mediaPlaye
         });
     };
 
+    mixins.testPauseSentinelActivatesWhenCurrentTimeRunsNormallyThenJumpsBackwardsWhenPaused = function(queue) {
+        expectAsserts(1);
+        var self = this;
+        runMediaPlayerTest(this, queue, function (MediaPlayer) {
+            getToPlaying(self, MediaPlayer);
+
+            advancePlayTime(self);
+            fireSentinels(self);
+
+            this._mediaPlayer.pause();
+            clearEvents(self);
+
+            stubCreateElementResults.video.currentTime = 0;
+            fireSentinels(self);
+
+            assertEvent(self, MediaPlayer.EVENT.SENTINEL_PAUSE);
+        });
+    };
+
     mixins.testEnterBufferingSentinelDoesNotActivateWhenPlaybackHaltsWhenOnlyOneSentinelIterationSinceStateChanged = function(queue) {
         expectAsserts(1);
         var self = this;

--- a/static/script-tests/tests/devices/mediaplayer/html5commontests.js
+++ b/static/script-tests/tests/devices/mediaplayer/html5commontests.js
@@ -1141,6 +1141,24 @@ window.commonTests.mediaPlayer.html5.mixinTests = function (testCase, mediaPlaye
         });
     };
 
+    mixins.testNoSentinelsActivateWhenCurrentTimeRunsNormallyThenJumpsBackwardsNearEndOfMedia = function(queue) {
+        expectAsserts(2);
+        var self = this;
+        runMediaPlayerTest(this, queue, function (MediaPlayer) {
+            getToPlayingAtEnd(self, MediaPlayer)
+            clearEvents(self);
+
+            advancePlayTime(self);
+            fireSentinels(self);
+
+            stubCreateElementResults.video.currentTime = 100;
+            fireSentinels(self);
+
+            assertNoEvents(self);
+            assertState(self, MediaPlayer.STATE.PLAYING);
+        });
+    };
+
     mixins.testEnterBufferingSentinelDoesNotActivateWhenPlaybackHaltsWhenOnlyOneSentinelIterationSinceStateChanged = function(queue) {
         expectAsserts(1);
         var self = this;

--- a/static/script/devices/mediaplayer/html5.js
+++ b/static/script/devices/mediaplayer/html5.js
@@ -647,7 +647,7 @@ require.def(
             },
 
             _endOfMediaSentinel: function() {
-                if (!this._hasSentinelTimeAdvanced && this._nearEndOfMedia) {
+                if (!this._hasSentinelTimeChanged && this._nearEndOfMedia) {
                     this._emitEvent(MediaPlayer.EVENT.SENTINEL_COMPLETE);
                     this._onEndOfMedia();
                     return true;

--- a/static/script/devices/mediaplayer/html5.js
+++ b/static/script/devices/mediaplayer/html5.js
@@ -616,7 +616,7 @@ require.def(
 
             _shouldBePausedSentinel: function() {
                 var sentinelActionTaken = false;
-                if (this._hasSentinelTimeAdvanced) {
+                if (this._hasSentinelTimeChanged) {
                     var mediaElement = this._mediaElement;
                     sentinelActionTaken = this._nextSentinelAttempt(this._sentinelLimits.pause, function() {
                         mediaElement.pause();
@@ -667,7 +667,6 @@ require.def(
                 this._sentinelInterval = setInterval(function() {
                     self._sentinelIntervalNumber += 1;
                     var newTime = self.getCurrentTime();
-                    self._hasSentinelTimeAdvanced = (newTime > self._lastSentinelTime + 0.2);
                     self._hasSentinelTimeChanged = (Math.abs(newTime - self._lastSentinelTime) > 0.2);
                     self._nearEndOfMedia = (self.getDuration() - (newTime || self._lastSentinelTime)) <= 1;
                     self._lastSentinelTime = newTime;


### PR DESCRIPTION
This makes the HTML5 sentinels more consistent, as the enter and exit buffering sentinels use time changed rather than time advanced.