### PR TITLE
Add getPlayerElement() to the new media player

### DIFF
--- a/static/script-tests/tests/devices/mediaplayer/cehtmlcommontests.js
+++ b/static/script-tests/tests/devices/mediaplayer/cehtmlcommontests.js
@@ -1361,7 +1361,15 @@ window.commonTests.mediaPlayer.cehtml.mixinTests = function (testCase, mediaPlay
         });
     };
 
-    // TODO: Consider whether the ordering of the pause and seek sentinels is important, and if so we need to assert the order in the tests.
+    mixins.testGetPlayerElement = function(queue) {
+        expectAsserts(1);
+        runMediaPlayerTest(this, queue, function (MediaPlayer) {
+            this._mediaPlayer.setSource(MediaPlayer.TYPE.VIDEO, 'testURL', 'video/mp4');
+            assertEquals(fakeCEHTMLObject, this._mediaPlayer.getPlayerElement());
+        });
+    };
+
+   // TODO: Consider whether the ordering of the pause and seek sentinels is important, and if so we need to assert the order in the tests.
 
     // *******************************************
     // ********* Mixin the functions *************

--- a/static/script-tests/tests/devices/mediaplayer/html5commontests.js
+++ b/static/script-tests/tests/devices/mediaplayer/html5commontests.js
@@ -1825,6 +1825,22 @@ window.commonTests.mediaPlayer.html5.mixinTests = function (testCase, mediaPlaye
         });
     };
 
+    mixins.testGetPlayerElementReturnsVideoElementForVideo = function(queue) {
+        expectAsserts(1);
+        runMediaPlayerTest(this, queue, function (MediaPlayer) {
+            this._mediaPlayer.setSource(MediaPlayer.TYPE.VIDEO, 'testURL', 'video/mp4');
+            assertEquals(stubCreateElementResults.video, this._mediaPlayer.getPlayerElement());
+        });
+    };
+
+    mixins.testGetPlayerElementReturnsAudioElementForAudio = function(queue) {
+        expectAsserts(1);
+        runMediaPlayerTest(this, queue, function (MediaPlayer) {
+            this._mediaPlayer.setSource(MediaPlayer.TYPE.AUDIO, 'testURL', 'audio/mp4');
+            assertEquals(stubCreateElementResults.audio, this._mediaPlayer.getPlayerElement());
+        });
+    };
+
     // TODO: Remove references to 'self' that are unecessary due to the use of '.call' in runMediaPlayerTest
     // TODO: Consider whether the ordering of the pause and seek sentinels is important, and if not we should not assert the order in the tests.
 

--- a/static/script-tests/tests/devices/mediaplayer/live/playable.js
+++ b/static/script-tests/tests/devices/mediaplayer/live/playable.js
@@ -83,6 +83,8 @@
 
     this.LivePlayerSupportLevelPlayableTest.prototype.testSeekableLivePlayerRemoveAllEventCallbacksCallsFunctionInMediaPlayer = testFunctionsInLivePlayerCallMediaPlayerFunctions('removeAllEventCallbacks', 0);
 
+    this.LivePlayerSupportLevelPlayableTest.prototype.testSeekableLivePlayerGetPlayerElementCallsFunctionInMediaPlayer = testFunctionsInLivePlayerCallMediaPlayerFunctions('getPlayerElement', 0);
+
     this.LivePlayerSupportLevelPlayableTest.prototype.testSeekableMediaPlayerFunctionsNotDefinedInPlayableLive = function (queue) {
         expectAsserts(6);
 
@@ -130,6 +132,19 @@
             this.sandbox.stub(livePlayer._mediaPlayer, 'getMimeType').returns("video/mp4");
 
             assertEquals("video/mp4", livePlayer.getMimeType());
+        }, config);
+    };
+
+    this.LivePlayerSupportLevelPlayableTest.prototype.testGetPlayerElementReturnsPlayerElement = function (queue) {
+        expectAsserts(1);
+        queuedApplicationInit(queue, 'lib/mockapplication', ["antie/devices/mediaplayer/mediaplayer", "antie/devices/device", "antie/devices/mediaplayer/live/playable"], function (application, MediaPlayer, Device) {
+            var device = new Device(antie.framework.deviceConfiguration);
+            var livePlayer = device.getLivePlayer();
+            var playerElement = "player element";
+
+            this.sandbox.stub(livePlayer._mediaPlayer, 'getPlayerElement').returns(playerElement);
+
+            assertEquals(playerElement, livePlayer.getPlayerElement());
         }, config);
     };
 })();

--- a/static/script-tests/tests/devices/mediaplayer/live/playable.js
+++ b/static/script-tests/tests/devices/mediaplayer/live/playable.js
@@ -81,9 +81,9 @@
 
     this.LivePlayerSupportLevelPlayableTest.prototype.testLivePlayerRemoveEventCallbackCallsFunctionInMediaPlayer = testFunctionsInLivePlayerCallMediaPlayerFunctions('removeEventCallback', 2);
 
-    this.LivePlayerSupportLevelPlayableTest.prototype.testSeekableLivePlayerRemoveAllEventCallbacksCallsFunctionInMediaPlayer = testFunctionsInLivePlayerCallMediaPlayerFunctions('removeAllEventCallbacks', 0);
+    this.LivePlayerSupportLevelPlayableTest.prototype.testLivePlayerRemoveAllEventCallbacksCallsFunctionInMediaPlayer = testFunctionsInLivePlayerCallMediaPlayerFunctions('removeAllEventCallbacks', 0);
 
-    this.LivePlayerSupportLevelPlayableTest.prototype.testSeekableLivePlayerGetPlayerElementCallsFunctionInMediaPlayer = testFunctionsInLivePlayerCallMediaPlayerFunctions('getPlayerElement', 0);
+    this.LivePlayerSupportLevelPlayableTest.prototype.testLivePlayerGetPlayerElementCallsFunctionInMediaPlayer = testFunctionsInLivePlayerCallMediaPlayerFunctions('getPlayerElement', 0);
 
     this.LivePlayerSupportLevelPlayableTest.prototype.testSeekableMediaPlayerFunctionsNotDefinedInPlayableLive = function (queue) {
         expectAsserts(6);

--- a/static/script-tests/tests/devices/mediaplayer/live/restartable.js
+++ b/static/script-tests/tests/devices/mediaplayer/live/restartable.js
@@ -85,6 +85,8 @@
 
     this.LivePlayerSupportLevelRestartableTest.prototype.testLivePlayerRemoveAllEventCallbacksCallsFunctionInMediaPlayer = testFunctionsInLivePlayerCallMediaPlayerFunctions('removeAllEventCallbacks', 0);
 
+    this.LivePlayerSupportLevelRestartableTest.prototype.testLivePlayerGetPlayerElementCallsFunctionInMediaPlayer = testFunctionsInLivePlayerCallMediaPlayerFunctions('getPlayerElement', 0);
+
     this.LivePlayerSupportLevelRestartableTest.prototype.testSeekableMediaPlayerFunctionsNotDefinedInRestartableLive = function (queue) {
         expectAsserts(5);
 
@@ -131,6 +133,19 @@
             this.sandbox.stub(livePlayer._mediaPlayer, 'getMimeType').returns("video/mp4");
 
             assertEquals("video/mp4", livePlayer.getMimeType());
+        }, config);
+    };
+
+    this.LivePlayerSupportLevelRestartableTest.prototype.testGetPlayerElementReturnsPlayerElement = function (queue) {
+        expectAsserts(1);
+        queuedApplicationInit(queue, 'lib/mockapplication', ["antie/devices/mediaplayer/mediaplayer", "antie/devices/device", "antie/devices/mediaplayer/live/restartable"], function (application, MediaPlayer, Device) {
+            var device = new Device(antie.framework.deviceConfiguration);
+            var livePlayer = device.getLivePlayer();
+            var playerElement = "player element";
+
+            this.sandbox.stub(livePlayer._mediaPlayer, 'getPlayerElement').returns(playerElement);
+
+            assertEquals(playerElement, livePlayer.getPlayerElement());
         }, config);
     };
 })();

--- a/static/script-tests/tests/devices/mediaplayer/live/seekable.js
+++ b/static/script-tests/tests/devices/mediaplayer/live/seekable.js
@@ -95,6 +95,8 @@
 
     this.LivePlayerSupportLevelSeekableTest.prototype.testSeekableLivePlayerGetSeekableRangeCallsFunctionInMediaPlayer = testFunctionsInLivePlayerCallMediaPlayerFunctions('getSeekableRange', 0);
 
+    this.LivePlayerSupportLevelSeekableTest.prototype.testSeekableLivePlayerGetPlayerElementCallsFunctionInMediaPlayer = testFunctionsInLivePlayerCallMediaPlayerFunctions('getPlayerElement', 0);
+
     this.LivePlayerSupportLevelSeekableTest.prototype.testGetStateReturnsState = function (queue) {
         expectAsserts(1);
         queuedApplicationInit(queue, 'lib/mockapplication', ["antie/devices/mediaplayer/mediaplayer", "antie/devices/device", "antie/devices/mediaplayer/live/seekable"], function(application, MediaPlayer, Device) {
@@ -154,6 +156,19 @@
             this.sandbox.stub(livePlayer._mediaPlayer, 'getSeekableRange').returns(expectedRange);
 
             assertEquals(expectedRange, livePlayer.getSeekableRange());
+        }, config);
+    };
+
+    this.LivePlayerSupportLevelSeekableTest.prototype.testGetPlayerElementReturnsPlayerElement = function (queue) {
+        expectAsserts(1);
+        queuedApplicationInit(queue, 'lib/mockapplication', ["antie/devices/mediaplayer/mediaplayer", "antie/devices/device", "antie/devices/mediaplayer/live/seekable"], function (application, MediaPlayer, Device) {
+            var device = new Device(antie.framework.deviceConfiguration);
+            var livePlayer = device.getLivePlayer();
+            var playerElement = "player element";
+
+            this.sandbox.stub(livePlayer._mediaPlayer, 'getPlayerElement').returns(playerElement);
+
+            assertEquals(playerElement, livePlayer.getPlayerElement());
         }, config);
     };
 })();

--- a/static/script-tests/tests/devices/mediaplayer/mediaplayer.js
+++ b/static/script-tests/tests/devices/mediaplayer/mediaplayer.js
@@ -328,4 +328,8 @@
         mediaPlayer.getState();
     });
 
+    this.MediaPlayerTest.prototype.testMediaPlayerGetPlayerElementThrowsAnExceptionWhenNotOverridden = testThatMediaPlayerFunctionThrowsError(function(mediaPlayer) {
+        mediaPlayer.getPlayerElement();
+    });
+
 })();

--- a/static/script-tests/tests/devices/mediaplayer/samsung_maple.js
+++ b/static/script-tests/tests/devices/mediaplayer/samsung_maple.js
@@ -1583,7 +1583,13 @@
         });
     };
 
-
+    this.SamsungMapleMediaPlayerTests.prototype.testGetPlayerElement = function(queue) {
+        expectAsserts(1);
+        runMediaPlayerTest(this, queue, function (MediaPlayer) {
+            this._mediaPlayer.setSource(MediaPlayer.TYPE.VIDEO, 'testURL', 'video/mp4');
+            assertEquals(playerPlugin, this._mediaPlayer.getPlayerElement());
+        });
+    };
 
     // **** WARNING **** WARNING **** WARNING: These TODOs are NOT complete/exhaustive
     // TODO: Investigate if we should keep a reference to the original player plugin and restore on tear-down in the same way media/samsung_maple modifier

--- a/static/script/devices/mediaplayer/cehtml.js
+++ b/static/script/devices/mediaplayer/cehtml.js
@@ -307,6 +307,13 @@ require.def(
                 return this._state;
             },
 
+            /**
+             * @inheritDoc
+             */
+            getPlayerElement: function() {
+                return this._mediaElement;
+            },
+
             _onFinishedBuffering: function() {
                 this._cacheRange();
 

--- a/static/script/devices/mediaplayer/html5.js
+++ b/static/script/devices/mediaplayer/html5.js
@@ -366,6 +366,13 @@ require.def(
                 return this._state;
             },
 
+            /**
+             * @inheritDoc
+             */
+            getPlayerElement: function() {
+                return this._mediaElement;
+            },
+
             _onFinishedBuffering: function() {
                 this._exitBuffering();
             },

--- a/static/script/devices/mediaplayer/live/playable.js
+++ b/static/script/devices/mediaplayer/live/playable.js
@@ -92,6 +92,10 @@ require.def(
 
             removeAllEventCallbacks: function() {
                 this._mediaPlayer.removeAllEventCallbacks();
+            },
+
+            getPlayerElement: function() {
+                return this._mediaPlayer.getPlayerElement();
             }
         });
 

--- a/static/script/devices/mediaplayer/live/restartable.js
+++ b/static/script/devices/mediaplayer/live/restartable.js
@@ -97,6 +97,10 @@ require.def(
 
             removeAllEventCallbacks: function() {
                 this._mediaPlayer.removeAllEventCallbacks();
+            },
+
+            getPlayerElement: function() {
+                return this._mediaPlayer.getPlayerElement();
             }
         });
 

--- a/static/script/devices/mediaplayer/live/seekable.js
+++ b/static/script/devices/mediaplayer/live/seekable.js
@@ -111,6 +111,10 @@ require.def(
 
             removeAllEventCallbacks: function() {
                 this._mediaPlayer.removeAllEventCallbacks();
+            },
+
+            getPlayerElement: function() {
+                return this._mediaPlayer.getPlayerElement();
             }
         });
 

--- a/static/script/devices/mediaplayer/mediaplayer.js
+++ b/static/script/devices/mediaplayer/mediaplayer.js
@@ -292,6 +292,14 @@ require.def(
                 throw new Error("getState method has not been implemented");
             },
 
+            /**
+             * Get the underlying DOM element used for media playback. Its type and signature will vary by device. In general this should not be used by client applications.
+             * @return {Element} Underlying DOM element used for media playback on this device.
+             */ 
+            getPlayerElement: function() {
+                throw new Error("getPlayerElement method has not been implemented");
+            },
+
             _getClampOffsetFromConfig: function() {
                 var clampOffsetFromEndOfRange;
                 var config = RuntimeContext.getDevice().getConfig();

--- a/static/script/devices/mediaplayer/mediaplayer.js
+++ b/static/script/devices/mediaplayer/mediaplayer.js
@@ -242,33 +242,33 @@ require.def(
             },
 
             /**
-            * Get the source MIME type.
-            * If no source is set (in state EMPTY for example), then this returns undefined.
-            * @return {String} The MIME type
-            */
+             * Get the source MIME type.
+             * If no source is set (in state EMPTY for example), then this returns undefined.
+             * @return {String} The MIME type
+             */
             getMimeType: function () {
                 throw new Error("getMimeType method has not been implemented");
             },
 
             /**
-            * Get the current play time.
-            * If no current time is available, then this returns undefined.
-            * @return {Number} The current play time in seconds from the start of the media.
-            */
+             * Get the current play time.
+             * If no current time is available, then this returns undefined.
+             * @return {Number} The current play time in seconds from the start of the media.
+             */
             getCurrentTime: function () {
                 throw new Error("getCurrentTime method has not been implemented");
             },
 
             /**
-            * Get the available seekable range of media.
-            * Returns a range Object with 'start' and 'end' numeric properties, giving the start and end of the available media in seconds from the start of the media.
-            * For VOD playback, 'start' is zero and 'end' is the last possible seek time (in many cases equal to duration).
-            * For Live playback, 'start' may be non-zero, reflecting the amount of 'live rewind' available before the current play position.
-            * For live playback, 'end' is the current live time.
-            * For live playback, both 'start' and 'end' may advance over time.
-            * If no range is available, this returns undefined.
-            * @return {Object} Object with 'start' and 'end' times in seconds, or undefined.
-            */
+             * Get the available seekable range of media.
+             * Returns a range Object with 'start' and 'end' numeric properties, giving the start and end of the available media in seconds from the start of the media.
+             * For VOD playback, 'start' is zero and 'end' is the last possible seek time (in many cases equal to duration).
+             * For Live playback, 'start' may be non-zero, reflecting the amount of 'live rewind' available before the current play position.
+             * For live playback, 'end' is the current live time.
+             * For live playback, both 'start' and 'end' may advance over time.
+             * If no range is available, this returns undefined.
+             * @return {Object} Object with 'start' and 'end' times in seconds, or undefined.
+             */
             getSeekableRange: function () {
                 throw new Error("getSeekableRange method has not been implemented");
             },
@@ -285,9 +285,9 @@ require.def(
             },
 
             /**
-            * Get the current state of the Media PLayer state machine.
-            * @return {antie.devices.mediaplayer.MediaPlayer.STATE} The current state of the Media Player state machine.
-            */
+             * Get the current state of the Media PLayer state machine.
+             * @return {antie.devices.mediaplayer.MediaPlayer.STATE} The current state of the Media Player state machine.
+             */
             getState: function () {
                 throw new Error("getState method has not been implemented");
             },
@@ -295,7 +295,7 @@ require.def(
             /**
              * Get the underlying DOM element used for media playback. Its type and signature will vary by device. In general this should not be used by client applications.
              * @return {Element} Underlying DOM element used for media playback on this device.
-             */ 
+             */
             getPlayerElement: function() {
                 throw new Error("getPlayerElement method has not been implemented");
             },
@@ -316,10 +316,10 @@ require.def(
         });
 
         /**
-        * An enumeration of possible media player states.
-        * @name antie.devices.mediaplayer.MediaPlayer.STATE
-        * @enum {String}
-        */
+         * An enumeration of possible media player states.
+         * @name antie.devices.mediaplayer.MediaPlayer.STATE
+         * @enum {String}
+         */
         MediaPlayer.STATE = {
             EMPTY:      "EMPTY",     // No source set
             STOPPED:    "STOPPED",   // Source set but no playback
@@ -331,10 +331,10 @@ require.def(
         };
 
         /**
-        * Media Player event names
-        * @name antie.devices.mediaplayer.MediaPlayer.EVENT
-        * @enum {String}
-        */
+         * Media Player event names
+         * @name antie.devices.mediaplayer.MediaPlayer.EVENT
+         * @enum {String}
+         */
         MediaPlayer.EVENT = {
             STOPPED:   "stopped",   // Event fired when playback is stopped
             BUFFERING: "buffering", // Event fired when playback has to suspend due to buffering

--- a/static/script/devices/mediaplayer/mediaplayer.js
+++ b/static/script/devices/mediaplayer/mediaplayer.js
@@ -293,7 +293,7 @@ require.def(
             },
 
             /**
-             * Get the underlying DOM element used for media playback. Its type and signature will vary by device. In general this should not be used by client applications.
+             * Get the underlying DOM element used for media playback. Its type and signature will vary by device. On devices that do not use HTML5 media playback this will not be a media element. In general this should not be used by client applications.
              * @return {Element} Underlying DOM element used for media playback on this device.
              */
             getPlayerElement: function() {

--- a/static/script/devices/mediaplayer/samsung_maple.js
+++ b/static/script/devices/mediaplayer/samsung_maple.js
@@ -296,6 +296,13 @@ require.def(
                 return this._state;
             },
 
+            /**
+             * @inheritDoc
+             */
+            getPlayerElement: function() {
+                return this._playerPlugin;
+            },
+
             _onFinishedBuffering: function() {
                 if (this.getState() !== MediaPlayer.STATE.BUFFERING) {
                     return;


### PR DESCRIPTION
Allow clients to access the underlying DOM element used for media playback, primarily for monitoring of the HTML5 media element.