### PR TITLE
TVPJSFRMWK-2401 - CEHTML Seek Sentinel Invoked Intermittently

### DIFF
--- a/static/script-tests/tests/devices/mediaplayer/cehtmlcommontests.js
+++ b/static/script-tests/tests/devices/mediaplayer/cehtmlcommontests.js
@@ -174,6 +174,8 @@ window.commonTests.mediaPlayer.cehtml.mixinTests = function (testCase, mediaPlay
                 deviceMockingHooks.mockTime();
                 self._device = application.getDevice();
                 self._mediaPlayer = self._device.getMediaPlayer();
+                self._eventCallback = self.sandbox.stub();
+                self._mediaPlayer.addEventCallback(null, self._eventCallback);
                 try {
                     action.call(self, MediaPlayer);
                 }
@@ -1339,6 +1341,25 @@ window.commonTests.mediaPlayer.cehtml.mixinTests = function (testCase, mediaPlay
             assertEventTypeHasFired(eventHandler, MediaPlayer.EVENT.SENTINEL_SEEK);
             assert(seekSpy.calledOnce);
             assertEquals(50000, seekSpy.getCall(0).args[0]);
+        });
+    };
+
+    mixins.testNoSeekSentinelActivatedWhenCurrentTimeIsReportedAsZeroDuringPlayback = function(queue) {
+        expectAsserts(1);
+        var self = this;
+        runMediaPlayerTest(this, queue, function (MediaPlayer) {
+            configureSeekToFail();
+            getToPlaying(this, MediaPlayer, 0);
+
+            var eventHandler = this.sandbox.stub();
+            this._mediaPlayer.addEventCallback(null, eventHandler);
+
+            deviceMockingHooks.makeOneSecondPass(this._mediaPlayer);
+
+            fakeCEHTMLObject.playPosition = 0;
+            fireSentinels(self);
+
+            assertEventTypeHasNotBeenFired(eventHandler, MediaPlayer.EVENT.SENTINEL_SEEK);
         });
     };
 

--- a/static/script-tests/tests/devices/mediaplayer/cehtmlcommontests.js
+++ b/static/script-tests/tests/devices/mediaplayer/cehtmlcommontests.js
@@ -1262,6 +1262,23 @@ window.commonTests.mediaPlayer.cehtml.mixinTests = function (testCase, mediaPlay
         });
     };
 
+    mixins.testSeekSentinelFiresWhenDeviceReportsPlaybackTimeAsZeroAfterReportingSuccessfulSeek = function(queue) {
+        expectAsserts(2);
+        runMediaPlayerTest(this, queue, function (MediaPlayer) {
+
+            var eventHandler = this.sandbox.stub();
+            this._mediaPlayer.addEventCallback(null, eventHandler);
+
+            getToPlaying(this, MediaPlayer, 30);
+            fireSentinels();
+            assertEventTypeHasNotBeenFired(eventHandler, MediaPlayer.EVENT.SENTINEL_SEEK);
+
+            fakeCEHTMLObject.playPosition = 0;
+            fireSentinels(this);
+            assertEventTypeHasBeenFiredASpecificNumberOfTimes(eventHandler, MediaPlayer.EVENT.SENTINEL_SEEK, 1);
+        });
+    };
+
     mixins.testFirstSentinelGivingUpDoesNotPreventSecondSentinelActivation = function(queue) {
         function xor(a, b) {
             return a !== b;

--- a/static/script-tests/tests/devices/mediaplayer/cehtmlcommontests.js
+++ b/static/script-tests/tests/devices/mediaplayer/cehtmlcommontests.js
@@ -1389,6 +1389,25 @@ window.commonTests.mediaPlayer.cehtml.mixinTests = function (testCase, mediaPlay
         });
     };
 
+    mixins.testSeekSentinelClampsTargetSeekTimeWhenPlayFromIsCalled = function(queue) {
+        expectAsserts(2);
+        var self = this;
+        runMediaPlayerTest(this, queue, function (MediaPlayer) {
+            getToPlaying(self, MediaPlayer, 0);
+
+            this._mediaPlayer.playFrom(200);
+
+            var eventHandler = this.sandbox.stub();
+            this._mediaPlayer.addEventCallback(null, eventHandler);
+
+            advancePlayTime();
+            fireSentinels(self);
+
+            assertEventTypeHasNotBeenFired(eventHandler, MediaPlayer.EVENT.SENTINEL_SEEK);
+            assertEquals(99900, fakeCEHTMLObject.playPosition);
+        });
+    };
+
     mixins.testNoSeekSentinelActivatedWhenCurrentTimeIsReportedAsZeroDuringPlayback = function(queue) {
         expectAsserts(1);
         var self = this;

--- a/static/script-tests/tests/devices/mediaplayer/cehtmlcommontests.js
+++ b/static/script-tests/tests/devices/mediaplayer/cehtmlcommontests.js
@@ -174,8 +174,6 @@ window.commonTests.mediaPlayer.cehtml.mixinTests = function (testCase, mediaPlay
                 deviceMockingHooks.mockTime();
                 self._device = application.getDevice();
                 self._mediaPlayer = self._device.getMediaPlayer();
-                self._eventCallback = self.sandbox.stub();
-                self._mediaPlayer.addEventCallback(null, self._eventCallback);
                 try {
                     action.call(self, MediaPlayer);
                 }
@@ -1383,10 +1381,13 @@ window.commonTests.mediaPlayer.cehtml.mixinTests = function (testCase, mediaPlay
             this._mediaPlayer.addEventCallback(null, eventHandler);
 
             for (var i=0; i<4; i++) {
-                fakeCEHTMLObject.playPosition = 0;
                 fireSentinels(self);
             }
-            assertEventTypeHasBeenFiredASpecificNumberOfTimes(eventHandler, MediaPlayer.EVENT.SENTINEL_SEEK, 2);
+
+            fakeCEHTMLObject.playPosition = 0;
+            fireSentinels(self);
+
+            assertEventTypeHasNotBeenFired(eventHandler, MediaPlayer.EVENT.SENTINEL_SEEK);
         });
     };
 

--- a/static/script-tests/tests/devices/mediaplayer/cehtmlcommontests.js
+++ b/static/script-tests/tests/devices/mediaplayer/cehtmlcommontests.js
@@ -1396,15 +1396,16 @@ window.commonTests.mediaPlayer.cehtml.mixinTests = function (testCase, mediaPlay
             getToPlaying(self, MediaPlayer, 0);
 
             this._mediaPlayer.playFrom(200);
+            deviceMockingHooks.finishBuffering(self._mediaPlayer);
 
             var eventHandler = this.sandbox.stub();
             this._mediaPlayer.addEventCallback(null, eventHandler);
 
-            advancePlayTime();
+            fakeCEHTMLObject.playPosition = 0;
             fireSentinels(self);
 
-            assertEventTypeHasNotBeenFired(eventHandler, MediaPlayer.EVENT.SENTINEL_SEEK);
-            assertEquals(99900, fakeCEHTMLObject.playPosition);
+            assertEventTypeHasFired(eventHandler, MediaPlayer.EVENT.SENTINEL_SEEK);
+            assertEquals(98900, fakeCEHTMLObject.playPosition);
         });
     };
 

--- a/static/script-tests/tests/devices/mediaplayer/cehtmlcommontests.js
+++ b/static/script-tests/tests/devices/mediaplayer/cehtmlcommontests.js
@@ -232,6 +232,17 @@ window.commonTests.mediaPlayer.cehtml.mixinTests = function (testCase, mediaPlay
         assertFalse(eventTypeHasFired(eventHandler, eventType));
     };
 
+    var assertEventTypeHasBeenFiredASpecificNumberOfTimes = function (eventHandler, eventType, expectedNumberOfCalls) {
+        var numberOfCalls = 0;
+
+        for(var i = 0; i < eventHandler.callCount; i++) {
+            if(eventHandler.getCall(i).args[0].type === eventType) {
+                numberOfCalls++;
+            }
+        }
+        assertEquals(expectedNumberOfCalls, numberOfCalls);
+    };
+
     var eventTypeHasFired = function(eventHandler, eventType) {
         for(var i = 0; i < eventHandler.callCount; i++) {
             if(eventHandler.getCall(i).args[0].type === eventType) {
@@ -1348,18 +1359,17 @@ window.commonTests.mediaPlayer.cehtml.mixinTests = function (testCase, mediaPlay
         expectAsserts(1);
         var self = this;
         runMediaPlayerTest(this, queue, function (MediaPlayer) {
-            configureSeekToFail();
-            getToPlaying(this, MediaPlayer, 0);
+            var SEEK_SENTINEL_TOLERANCE = 15;
+            getToPlaying(this, MediaPlayer, SEEK_SENTINEL_TOLERANCE + 20);
 
             var eventHandler = this.sandbox.stub();
             this._mediaPlayer.addEventCallback(null, eventHandler);
 
-            deviceMockingHooks.makeOneSecondPass(this._mediaPlayer);
-
-            fakeCEHTMLObject.playPosition = 0;
-            fireSentinels(self);
-
-            assertEventTypeHasNotBeenFired(eventHandler, MediaPlayer.EVENT.SENTINEL_SEEK);
+            for (var i=0; i<4; i++) {
+                fakeCEHTMLObject.playPosition = 0;
+                fireSentinels(self);
+            }
+            assertEventTypeHasBeenFiredASpecificNumberOfTimes(eventHandler, MediaPlayer.EVENT.SENTINEL_SEEK, 2);
         });
     };
 

--- a/static/script-tests/tests/devices/mediaplayer/cehtmlcommontests.js
+++ b/static/script-tests/tests/devices/mediaplayer/cehtmlcommontests.js
@@ -1370,6 +1370,25 @@ window.commonTests.mediaPlayer.cehtml.mixinTests = function (testCase, mediaPlay
         });
     };
 
+    mixins.testSeekSentinelClampsTargetSeekTimeWhenRequired = function(queue) {
+        expectAsserts(2);
+        var self = this;
+        runMediaPlayerTest(this, queue, function (MediaPlayer) {
+            getToBuffering(self, MediaPlayer, 110);
+            deviceMockingHooks.finishBuffering(self._mediaPlayer);
+            fakeCEHTMLObject.playPosition = 0;
+
+            var eventHandler = this.sandbox.stub();
+            this._mediaPlayer.addEventCallback(null, eventHandler);
+
+            advancePlayTime();
+            fireSentinels(self);
+
+            assertEventTypeHasFired(eventHandler, MediaPlayer.EVENT.SENTINEL_SEEK);
+            assertEquals(98900, fakeCEHTMLObject.playPosition);
+        });
+    };
+
     mixins.testNoSeekSentinelActivatedWhenCurrentTimeIsReportedAsZeroDuringPlayback = function(queue) {
         expectAsserts(1);
         var self = this;
@@ -1380,7 +1399,7 @@ window.commonTests.mediaPlayer.cehtml.mixinTests = function (testCase, mediaPlay
             var eventHandler = this.sandbox.stub();
             this._mediaPlayer.addEventCallback(null, eventHandler);
 
-            for (var i=0; i<4; i++) {
+            for (var i=0; i<3; i++) {
                 fireSentinels(self);
             }
 

--- a/static/script/devices/mediaplayer/cehtml.js
+++ b/static/script/devices/mediaplayer/cehtml.js
@@ -95,7 +95,6 @@ require.def(
             * @inheritDoc
             */
             playFrom: function (seconds) {
-                this._sentinelSeekTime = seconds;
                 this._postBufferingState = MediaPlayer.STATE.PLAYING;
                 this._sentinelLimits.seek.currentAttemptCount = 0;
                 switch (this.getState()) {
@@ -134,7 +133,6 @@ require.def(
             */
             beginPlayback: function() {
                 this._postBufferingState = MediaPlayer.STATE.PLAYING;
-                this._sentinelSeekTime = undefined;
                 switch (this.getState()) {
                     case MediaPlayer.STATE.STOPPED:
                         this._toBuffering();

--- a/static/script/devices/mediaplayer/cehtml.js
+++ b/static/script/devices/mediaplayer/cehtml.js
@@ -589,6 +589,7 @@ require.def(
 
                 var SEEK_TOLERANCE = 15;
                 var currentTime = this.getCurrentTime();
+                
                 var clampedSentinelSeekTime = this._getClampedTime(this._sentinelSeekTime);
 
                 var sentinelSeekRequired = Math.abs(clampedSentinelSeekTime - currentTime) > SEEK_TOLERANCE;
@@ -596,15 +597,14 @@ require.def(
 
                 if (sentinelSeekRequired) {
                     var mediaElement = this._mediaElement;
-                      sentinelActionTaken = this._nextSentinelAttempt(this._sentinelLimits.seek, function () {
-                          mediaElement.seek(clampedSentinelSeekTime * 1000);
-                      });
+                    sentinelActionTaken = this._nextSentinelAttempt(this._sentinelLimits.seek, function () {
+                        mediaElement.seek(clampedSentinelSeekTime * 1000);
+                    });
                 } else if (this._sentinelIntervalNumber < 3) {
                     this._sentinelSeekTime = currentTime;
                 } else {
                     this._sentinelSeekTime = undefined;
                 }
-
                 return sentinelActionTaken;
             },
 

--- a/static/script/devices/mediaplayer/cehtml.js
+++ b/static/script/devices/mediaplayer/cehtml.js
@@ -151,7 +151,6 @@ require.def(
              * @inheritDoc
              */
             beginPlaybackFrom: function(seconds) {
-                this._sentinelSeekTime = undefined;
                 this._postBufferingState = MediaPlayer.STATE.PLAYING;
                 this._sentinelLimits.seek.currentAttemptCount = 0;
 


### PR DESCRIPTION
Resolves issue where seek sentinel fires during live playback when device reports time as zero. The fix is one similar that was made to html5. 