### PR TITLE
Fix adding multiple event handlers with same function body

### DIFF
--- a/static/script-tests/tests/widgets/widget.js
+++ b/static/script-tests/tests/widgets/widget.js
@@ -169,6 +169,22 @@
         );
     };
 
+    this.WidgetTest.prototype.testRemoveNonexistentEventListener = function(queue) {
+        expectAsserts(1);
+
+        queuedApplicationInit(
+            queue,
+            "lib/mockapplication",
+            ["antie/widgets/widget", "antie/events/event"],
+            function(application, Widget, Event) {
+                var widget = new Widget();
+                var handler = this.sandbox.stub();
+                var result = widget.removeEventListener('anevent', handler);
+                assertFalse(result);
+            }
+        );
+    };
+
     this.WidgetTest.prototype.testBubbleEvent = function(queue) {
         expectAsserts(3);
 

--- a/static/script-tests/tests/widgets/widget.js
+++ b/static/script-tests/tests/widgets/widget.js
@@ -17,7 +17,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * 
+ *
  * All rights reserved
  * Please contact us for an alternative licence
  */
@@ -132,7 +132,7 @@
     };
 
     this.WidgetTest.prototype.testAddEventListener = function(queue) {
-        expectAsserts(1);
+        expectAsserts(2);
 
         queuedApplicationInit(
             queue,
@@ -140,10 +140,13 @@
             ["antie/widgets/widget", "antie/events/event"],
             function(application, Widget, Event) {
                 var widget = new Widget();
-                var handler = this.sandbox.stub();
+                var handler = this.sandbox.stub(),
+                    handler2 = this.sandbox.stub();
                 widget.addEventListener('anevent', handler);
+                widget.addEventListener('anevent', handler2);
                 widget.fireEvent(new Event('anevent'));
                 assert(handler.called);
+                assert(handler2.called);
             }
         );
     };

--- a/static/script/events/event.js
+++ b/static/script/events/event.js
@@ -41,7 +41,7 @@ require.def('antie/events/event',
 
 		var eventCount = 0;
 		var eventListeners = {};
-	
+
 		/**
 	 	 * Abstract base class for events.
 	 	 * @abstract
@@ -100,12 +100,13 @@ require.def('antie/events/event',
 			 */
 			addEventListener: function(ev, func) {
 				var listeners = eventListeners[ev];
-				if(!listeners) {
-					listeners = eventListeners[ev] = {};
-				}
-				if(!listeners[func]) {
-					listeners[func] = func;
-				}
+                if (typeof listeners === 'undefined') {
+                    listeners = [];
+                    eventListeners[ev] = listeners;
+                }
+                if (!~listeners.indexOf(func)) {
+                    listeners.push(func);
+                }
 			},
 			/**
 			 * Removes an event listener function to the event stack. Used for 'meta-events'.
@@ -115,10 +116,11 @@ require.def('antie/events/event',
 			 * @param {Function} func The handler to be removed.
 			 */
 			removeEventListener: function(ev, func) {
-				var listeners = eventListeners[ev];
-				if(listeners && listeners[func]) {
-					delete(listeners[func]);
-				}
+				var listeners = eventListeners[ev],
+                    listener = listeners.indexOf(func);
+                if (~listener) {
+                    listeners.splice(listener, 1);
+                }
 			},
 			/**
 			 * Fires an event on the event stack.

--- a/static/script/events/event.js
+++ b/static/script/events/event.js
@@ -35,8 +35,8 @@
  */
 
 require.def('antie/events/event',
-	['antie/class'],
-	function(Class) {
+	['antie/class', 'antie/runtimecontext'],
+	function(Class, RuntimeContext) {
 		'use strict';
 
 		var eventCount = 0;
@@ -117,7 +117,14 @@ require.def('antie/events/event',
 			 */
 			removeEventListener: function(ev, func) {
 				var listeners = eventListeners[ev],
-                    listener = listeners.indexOf(func);
+                    listener;
+
+                if (!listeners) {
+                    RuntimeContext.getDevice().getLogger().error('Attempting to remove non-existent event listener');
+                    return false;
+                }
+
+                listener = listeners.indexOf(func);
                 if (~listener) {
                     listeners.splice(listener, 1);
                 }

--- a/static/script/widgets/widget.js
+++ b/static/script/widgets/widget.js
@@ -138,7 +138,9 @@ require.def('antie/widgets/widget',
                     listeners = [];
                     this._eventListeners[ev] = listeners;
                 }
-                listeners.push(func);
+                if (!~listeners.indexOf(func)) {
+                    listeners.push(func);
+                }
             },
             /**
              * Removes an event listener function to this widget.

--- a/static/script/widgets/widget.js
+++ b/static/script/widgets/widget.js
@@ -150,7 +150,14 @@ require.def('antie/widgets/widget',
              */
             removeEventListener: function(ev, func) {
                 var listeners = this._eventListeners[ev],
-                    listener = listeners.indexOf(func);
+                    listener;
+
+                if (!listeners) {
+                    RuntimeContext.getDevice().getLogger().error('Attempting to remove non-existent event listener');
+                    return false;
+                }
+
+                listener = listeners.indexOf(func);
                 if (~listener) {
                     listeners.splice(listener, 1);
                 }

--- a/static/script/widgets/widget.js
+++ b/static/script/widgets/widget.js
@@ -19,7 +19,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * 
+ *
  * All rights reserved
  * Please contact us for an alternative licence
  */
@@ -134,12 +134,11 @@ require.def('antie/widgets/widget',
              */
             addEventListener: function(ev, func) {
                 var listeners = this._eventListeners[ev];
-                if (!listeners) {
-                    listeners = this._eventListeners[ev] = {};
+                if (typeof listeners === 'undefined') {
+                    listeners = [];
+                    this._eventListeners[ev] = listeners;
                 }
-                if (!listeners[func]) {
-                    listeners[func] = func;
-                }
+                listeners.push(func);
             },
             /**
              * Removes an event listener function to this widget.
@@ -148,9 +147,10 @@ require.def('antie/widgets/widget',
              * @see antie.events.Event
              */
             removeEventListener: function(ev, func) {
-                var listeners = this._eventListeners[ev];
-                if (listeners && listeners[func]) {
-                    delete(listeners[func]);
+                var listeners = this._eventListeners[ev],
+                    listener = listeners.indexOf(func);
+                if (~listener) {
+                    listeners.splice(listener, 1);
                 }
             },
             /**


### PR DESCRIPTION
Hello,

When trying to add multiple event listeners to a widget, with the same function body, only the first event gets fired. This is because the events are stored on an object with the function as a key. Because javascript internally does `.toString` on the function when applying it as key it can only store one event with that function body.

Normally this is not a problem, but when using `.bind` the function body will automatically become `function () { [native code] }` and thus only one bound function will be able to be set to that listener.

This fix checks for the function reference itself and thus is able to add multiple bound event listeners.