### PR TITLE
Remove Array.indexOf calls

### DIFF
--- a/static/script-tests/tests/widgets/widget.js
+++ b/static/script-tests/tests/widgets/widget.js
@@ -132,7 +132,7 @@
     };
 
     this.WidgetTest.prototype.testAddEventListener = function(queue) {
-        expectAsserts(2);
+        expectAsserts(3);
 
         queuedApplicationInit(
             queue,
@@ -142,19 +142,21 @@
                 var widget = new Widget();
                 var handler = this.sandbox.stub(),
                     handler2 = this.sandbox.stub();
+                var indexOfSpy = this.sandbox.spy(application.getDevice(), 'arrayIndexOf');
+
                 widget.addEventListener('anevent', handler);
                 widget.addEventListener('anevent', handler2);
                 widget.fireEvent(new Event('anevent'));
                 assert(handler.called);
                 assert(handler2.called);
+                assert(indexOfSpy.calledTwice);
             }
         );
     };
 
     this.WidgetTest.prototype.testRemoveEventListener = function(queue) {
         expectAsserts(2);
-        var config = JSON.parse(JSON.stringify(antie.framework.deviceConfiguration));
-        config.modules.base = "antie/devices/browserdevice";
+
         queuedApplicationInit(
             queue,
             "lib/mockapplication",
@@ -169,7 +171,8 @@
                 widget.fireEvent(new Event('anevent'));
                 assertFalse(handler.called);
                 assert(indexOfSpy.calledOnce);
-            }, config);
+            }
+        );
     };
 
     this.WidgetTest.prototype.testRemoveNonexistentEventListener = function(queue) {

--- a/static/script-tests/tests/widgets/widget.js
+++ b/static/script-tests/tests/widgets/widget.js
@@ -152,8 +152,9 @@
     };
 
     this.WidgetTest.prototype.testRemoveEventListener = function(queue) {
-        expectAsserts(1);
-
+        expectAsserts(2);
+        var config = JSON.parse(JSON.stringify(antie.framework.deviceConfiguration));
+        config.modules.base = "antie/devices/browserdevice";
         queuedApplicationInit(
             queue,
             "lib/mockapplication",
@@ -162,11 +163,13 @@
                 var widget = new Widget();
                 var handler = this.sandbox.stub();
                 widget.addEventListener('anevent', handler);
+                var indexOfSpy = this.sandbox.spy(application.getDevice(), 'arrayIndexOf');
+
                 widget.removeEventListener('anevent', handler);
                 widget.fireEvent(new Event('anevent'));
                 assertFalse(handler.called);
-            }
-        );
+                assert(indexOfSpy.calledOnce);
+            }, config);
     };
 
     this.WidgetTest.prototype.testRemoveNonexistentEventListener = function(queue) {

--- a/static/script/devices/sanitisers/whitelisted.js
+++ b/static/script/devices/sanitisers/whitelisted.js
@@ -24,8 +24,11 @@
  * Please contact us for an alternative licence
  */
  require.def('antie/devices/sanitisers/whitelisted', 
-    ['antie/devices/sanitiser'],
-    function (Sanitiser) {
+    [
+        'antie/devices/sanitiser',
+        'antie/runtimecontext'
+    ],
+    function (Sanitiser, RuntimeContext) {
 
     'use strict';
 
@@ -119,7 +122,7 @@
 
             for (var i = 0; i < content.length; i++) {
                 if (content[i].tagName) {
-                    if (this._whitelist.indexOf(content[i].tagName) !== -1) {
+                    if (RuntimeContext.getDevice().arrayIndexOf(this._whitelist, content[i].tagName) !== -1) {
                         el = document.createElement(content[i].tagName);
                         el = this._processDomElement(content[i], el);
                         originalDom.appendChild(el);

--- a/static/script/events/event.js
+++ b/static/script/events/event.js
@@ -104,7 +104,7 @@ require.def('antie/events/event',
                     listeners = [];
                     eventListeners[ev] = listeners;
                 }
-                if (!~listeners.indexOf(func)) {
+                if (!~RuntimeContext.getDevice().arrayIndexOf(listeners, func)) {
                     listeners.push(func);
                 }
 			},
@@ -124,7 +124,7 @@ require.def('antie/events/event',
                     return false;
                 }
 
-                listener = listeners.indexOf(func);
+                listener = RuntimeContext.getDevice().arrayIndexOf(listeners, func);
                 if (~listener) {
                     listeners.splice(listener, 1);
                 }

--- a/static/script/widgets/widget.js
+++ b/static/script/widgets/widget.js
@@ -157,7 +157,7 @@ require.def('antie/widgets/widget',
                     return false;
                 }
 
-                listener = listeners.indexOf(func);
+                listener = RuntimeContext.getDevice().arrayIndexOf(listeners, func);
                 if (~listener) {
                     listeners.splice(listener, 1);
                 }

--- a/static/script/widgets/widget.js
+++ b/static/script/widgets/widget.js
@@ -138,7 +138,7 @@ require.def('antie/widgets/widget',
                     listeners = [];
                     this._eventListeners[ev] = listeners;
                 }
-                if (!~listeners.indexOf(func)) {
+                if (!~RuntimeContext.getDevice().arrayIndexOf(listeners, func)) {
                     listeners.push(func);
                 }
             },


### PR DESCRIPTION
Some browsers may not support EcmaScript 5, so we should use arrayIndexOf in antie/browserdevice instead. This is related to #267. 