### PR TITLE
Iplayertvv1 3235

### DIFF
--- a/static/script-tests/tests/devices/mediaplayer/cehtmlcommontests.js
+++ b/static/script-tests/tests/devices/mediaplayer/cehtmlcommontests.js
@@ -655,7 +655,7 @@ window.commonTests.mediaPlayer.cehtml.mixinTests = function (testCase, mediaPlay
     };
 
     mixins.testDeviceErrorIsReportedWithErrorCode = function(queue) {
-        expectAsserts(2);
+        expectAsserts(3);
         runMediaPlayerTest(this, queue, function (MediaPlayer) {
             var errorStub = this.sandbox.stub();
             this.sandbox.stub(this._device, "getLogger").returns({error: errorStub});
@@ -669,8 +669,11 @@ window.commonTests.mediaPlayer.cehtml.mixinTests = function (testCase, mediaPlay
             fakeCEHTMLObject.error = 2;
             deviceMockingHooks.emitPlaybackError(this._mediaPlayer);
 
+            var expectedErrorMessage = 'Media element error code: 2';
+
             assertEquals(MediaPlayer.EVENT.ERROR, eventHandler.lastCall.args[0].type);
-            assertEquals('Media element emitted error with code: 2', errorStub.lastCall.args[0]);
+            assertEquals(expectedErrorMessage, eventHandler.lastCall.args[0].errorMessage);
+            assertEquals(expectedErrorMessage, errorStub.lastCall.args[0]);
         });
     };
 

--- a/static/script-tests/tests/devices/mediaplayer/html5commontests.js
+++ b/static/script-tests/tests/devices/mediaplayer/html5commontests.js
@@ -28,7 +28,6 @@ window.commonTests.mediaPlayer.html5 = window.commonTests.mediaPlayer.html5 || {
 
 window.commonTests.mediaPlayer.html5.mixinTests = function (testCase, mediaPlayerDeviceModifierRequireName, config) {
 
-
     var mixins = { };
     var clock;
     var stubCreateElementResults = undefined;
@@ -272,7 +271,7 @@ window.commonTests.mediaPlayer.html5.mixinTests = function (testCase, mediaPlaye
     };
 
     var eventWasFired = function(self, eventType) {
-        for( i = 0; i < self._eventCallback.args.length; i++) {
+        for( var i = 0; i < self._eventCallback.args.length; i++) {
             if(eventType === self._eventCallback.args[i][0].type) {
                 return true;
             }
@@ -281,7 +280,7 @@ window.commonTests.mediaPlayer.html5.mixinTests = function (testCase, mediaPlaye
     };
 
     var eventWasFiredWithPropertyValue = function(self, eventType, property, value) {
-        for( i = 0; i < self._eventCallback.args.length; i++) {
+        for( var i = 0; i < self._eventCallback.args.length; i++) {
             var event = self._eventCallback.args[i][0];
             if(eventType === event.type && value === event[property]) {
                 return true;
@@ -305,7 +304,7 @@ window.commonTests.mediaPlayer.html5.mixinTests = function (testCase, mediaPlaye
     var assertEventTypeHasBeenFiredASpecificNumberOfTimes = function (self, eventType, expectedNumberOfCalls) {
         var numberOfCalls = 0;
 
-        for( i = 0; i < self._eventCallback.args.length; i++) {
+        for( var i = 0; i < self._eventCallback.args.length; i++) {
             if(eventType === self._eventCallback.args[i][0].type) {
                 numberOfCalls++;
             }

--- a/static/script-tests/tests/devices/mediaplayer/html5commontests.js
+++ b/static/script-tests/tests/devices/mediaplayer/html5commontests.js
@@ -278,7 +278,17 @@ window.commonTests.mediaPlayer.html5.mixinTests = function (testCase, mediaPlaye
             }
         }
         return false;
-    }
+    };
+
+    var eventWasFiredWithPropertyValue = function(self, eventType, property, value) {
+        for( i = 0; i < self._eventCallback.args.length; i++) {
+            var event = self._eventCallback.args[i][0];
+            if(eventType === event.type && value === event[property]) {
+                return true;
+            }
+        }
+        return false;
+    };
 
     var assertEvent = function(self, eventType) {
         assertTrue(eventWasFired(self, eventType));
@@ -286,7 +296,7 @@ window.commonTests.mediaPlayer.html5.mixinTests = function (testCase, mediaPlaye
 
     var assertNoEvent = function(self, eventType) {
         assertFalse(eventWasFired(self, eventType));
-    }
+    };
 
     var assertNoEvents = function(self) {
         assert(self._eventCallback.notCalled);
@@ -549,25 +559,27 @@ window.commonTests.mediaPlayer.html5.mixinTests = function (testCase, mediaPlaye
         });
     };
 
-    mixins.testErrorEventFromMediaElementCausesErrorLogWithCode = function(queue) {
-        expectAsserts(2);
+    mixins.testErrorEventFromMediaElementCausesErrorLogWithCodeAndErrorMessageInEvent = function(queue) {
+        expectAsserts(3);
         var self = this;
 		runMediaPlayerTest(this, queue, function (MediaPlayer) {
 
             var errorStub = self.sandbox.stub();
             self.sandbox.stub(self._device, "getLogger").returns({error: errorStub});
 
-            self._mediaPlayer.setSource(MediaPlayer.TYPE.VIDEO, 'http://testurl/', 'video/mp4');
+            self._mediaPlayer.setSource(MediaPlayer.TYPE.VIDEO, "http://testurl/", "video/mp4");
 
             assertFunction(mediaEventListeners.error);
 
             deviceMockingHooks.emitPlaybackError(self._mediaPlayer, 3); // MEDIA_ERR_DECODE - http://www.w3.org/TR/2011/WD-html5-20110405/video.html#dom-media-error
 
-            assert(errorStub.calledWith("Media element emitted error with code: 3"));
+            var errorMessage = "Media element error code: 3";
+            assert(errorStub.calledWith(errorMessage));
+            assert(eventWasFiredWithPropertyValue(self, MediaPlayer.EVENT.ERROR, "errorMessage", errorMessage));
         });
     };
 
-    mixins.testErrorEventFromSourceElementCausesErrorLog = function(queue) {
+    mixins.testErrorEventFromSourceElementCausesErrorLogAndErrorMessageInEvent = function(queue) {
         expectAsserts(3);
         var self = this;
         runMediaPlayerTest(this, queue, function (MediaPlayer) {
@@ -580,8 +592,9 @@ window.commonTests.mediaPlayer.html5.mixinTests = function (testCase, mediaPlaye
 
             emitSourceElementError();
 
-            assert(errorStub.calledWith("Media source element emitted an error"));
-            assertEvent(self, MediaPlayer.EVENT.ERROR);
+            var errorMessage = "Media source element error";
+            assert(errorStub.calledWith(errorMessage));
+            assert(eventWasFiredWithPropertyValue(self, MediaPlayer.EVENT.ERROR, "errorMessage", errorMessage));
         });
     };
 

--- a/static/script-tests/tests/devices/mediaplayer/samsung_maple.js
+++ b/static/script-tests/tests/devices/mediaplayer/samsung_maple.js
@@ -671,6 +671,14 @@
         });
     };
 
+    function assert_x3_matchErrorEvent(eventHandler, expectedErrorType, expectedErrorMessage) {
+        var actualEventArgs = eventHandler.args[0][0];
+
+        assert(eventHandler.calledOnce);
+        assertEquals(expectedErrorType, actualEventArgs.type);
+        assertEquals(expectedErrorMessage, actualEventArgs.errorMessage);
+    }
+
     this.SamsungMapleMediaPlayerTests.prototype.testOnRenderErrorCausesErrorEvent = function(queue) {
         expectAsserts(4);
         runMediaPlayerTest(this, queue, function(MediaPlayer) {
@@ -682,11 +690,10 @@
 
             window.SamsungMapleOnRenderError();
 
-            assert(eventHandler.calledOnce);
-            assertEquals(MediaPlayer.EVENT.ERROR, eventHandler.args[0][0].type);
-            assert(this._errorLog.calledOnce);
-            assert(this._errorLog.calledWith("Media element emitted OnRenderError"));
+            var expectedError = "Media element emitted OnRenderError";
+            assert_x3_matchErrorEvent(eventHandler, MediaPlayer.EVENT.ERROR, expectedError);
 
+            assert(this._errorLog.withArgs(expectedError).calledOnce);
         });
     };
 
@@ -701,11 +708,10 @@
 
             window.SamsungMapleOnConnectionFailed();
 
-            assert(eventHandler.calledOnce);
-            assertEquals(MediaPlayer.EVENT.ERROR, eventHandler.args[0][0].type);
-            assert(this._errorLog.calledOnce);
-            assert(this._errorLog.calledWith("Media element emitted OnConnectionFailed"));
+            var expectedError = "Media element emitted OnConnectionFailed";
+            assert_x3_matchErrorEvent(eventHandler, MediaPlayer.EVENT.ERROR, expectedError);
 
+            assert(this._errorLog.withArgs(expectedError).calledOnce);
         });
     };
 
@@ -720,11 +726,10 @@
 
             window.SamsungMapleOnNetworkDisconnected();
 
-            assert(eventHandler.calledOnce);
-            assertEquals(MediaPlayer.EVENT.ERROR, eventHandler.args[0][0].type);
-            assert(this._errorLog.calledOnce);
-            assert(this._errorLog.calledWith("Media element emitted OnNetworkDisconnected"));
+            var expectedError = "Media element emitted OnNetworkDisconnected";
+            assert_x3_matchErrorEvent(eventHandler, MediaPlayer.EVENT.ERROR, expectedError);
 
+            assert(this._errorLog.withArgs(expectedError).calledOnce);
         });
     };
 
@@ -739,11 +744,10 @@
 
             window.SamsungMapleOnStreamNotFound();
 
-            assert(eventHandler.calledOnce);
-            assertEquals(MediaPlayer.EVENT.ERROR, eventHandler.args[0][0].type);
-            assert(this._errorLog.calledOnce);
-            assert(this._errorLog.calledWith("Media element emitted OnStreamNotFound"));
+            var expectedError = "Media element emitted OnStreamNotFound";
+            assert_x3_matchErrorEvent(eventHandler, MediaPlayer.EVENT.ERROR, expectedError);
 
+            assert(this._errorLog.withArgs(expectedError).calledOnce);
         });
     };
 
@@ -758,11 +762,10 @@
 
             window.SamsungMapleOnAuthenticationFailed();
 
-            assert(eventHandler.calledOnce);
-            assertEquals(MediaPlayer.EVENT.ERROR, eventHandler.args[0][0].type);
-            assert(this._errorLog.calledOnce);
-            assert(this._errorLog.calledWith("Media element emitted OnAuthenticationFailed"));
+            var expectedError = "Media element emitted OnAuthenticationFailed";
+            assert_x3_matchErrorEvent(eventHandler, MediaPlayer.EVENT.ERROR, expectedError);
 
+            assert(this._errorLog.withArgs(expectedError).calledOnce);
         });
     };
 

--- a/static/script/devices/mediaplayer/cehtml.js
+++ b/static/script/devices/mediaplayer/cehtml.js
@@ -325,7 +325,7 @@ require.def(
             },
 
             _onDeviceError: function() {
-                this._reportError('Media element emitted error with code: ' + this._mediaElement.error);
+                this._reportError("Media element error code: " + this._mediaElement.error);
             },
 
             _onDeviceBuffering: function() {
@@ -458,7 +458,7 @@ require.def(
 
             _reportError: function(errorMessage) {
                 RuntimeContext.getDevice().getLogger().error(errorMessage);
-                this._emitEvent(MediaPlayer.EVENT.ERROR);
+                this._emitEvent(MediaPlayer.EVENT.ERROR, {"errorMessage": errorMessage});
             },
 
             _toStopped: function () {

--- a/static/script/devices/mediaplayer/html5.js
+++ b/static/script/devices/mediaplayer/html5.js
@@ -382,11 +382,11 @@ require.def(
             },
 
             _onDeviceError: function() {
-                this._reportError("Media element emitted error with code: " + this._mediaElement.error.code);
+                this._reportError("Media element error code: " + this._mediaElement.error.code);
             },
 
             _onSourceError: function() {
-                this._reportError("Media source element emitted an error");
+                this._reportError("Media source element error");
             },
 
             /**
@@ -521,7 +521,7 @@ require.def(
 
             _reportError: function(errorMessage) {
                 RuntimeContext.getDevice().getLogger().error(errorMessage);
-                this._emitEvent(MediaPlayer.EVENT.ERROR);
+                this._emitEvent(MediaPlayer.EVENT.ERROR, {"errorMessage": errorMessage});
             },
 
             _toStopped: function() {

--- a/static/script/devices/mediaplayer/mediaplayer.js
+++ b/static/script/devices/mediaplayer/mediaplayer.js
@@ -83,9 +83,10 @@ require.def(
              * Protected method, for use by subclasses to emit events of any specified type, adding in the
              * standard payload used by all events.
              * @param {String} eventType The type of the event to be emitted.
+             * @param {Object} [eventLabels] Optional additional event labels.
              * @protected
              */
-            _emitEvent: function(eventType) {
+            _emitEvent: function(eventType, eventLabels) {
 
                 var event = {
                     type: eventType,
@@ -96,6 +97,12 @@ require.def(
                     mimeType: this.getMimeType(),
                     state: this.getState()
                 };
+
+                if (eventLabels) {
+                    for (var key in eventLabels) {
+                        event[key] = eventLabels[key];
+                    }
+                }
 
                 this._callbackManager.callAll(event);
             },

--- a/static/script/devices/mediaplayer/samsung_maple.js
+++ b/static/script/devices/mediaplayer/samsung_maple.js
@@ -538,7 +538,7 @@ require.def(
 
             _reportError: function(errorMessage) {
                 RuntimeContext.getDevice().getLogger().error(errorMessage);
-                this._emitEvent(MediaPlayer.EVENT.ERROR);
+                this._emitEvent(MediaPlayer.EVENT.ERROR, {"errorMessage": errorMessage});
             },
 
             _toStopped: function () {


### PR DESCRIPTION
As part of platform stats we would like to know when media tag has errored as a DAX hidden page stat.
Media Element error events are bubbled up but the actual error code/message is not part of the event.
This work adds a 'errorMessage' field to the event.

There are no SC breaks and no new logic added.

Changes are made to html5/cehtml/samsung_maple devices and their unit tests.
