### PR TITLE
Package managers versions, add grunt-bump, fix #297

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "tal",
-  "version": "3.0.2",
+  "version": "3.0.4",
   "homepage": "http://fmtvp.github.io/tal/index.html",
   "description": "TAL was developed internally within the BBC as a way of vastly simplifying TV application development whilst increasing the reach of BBC TV applications such as iPlayer. Today all of the BBC’s HTML-based TV applications are built using TAL.",
   "main": "static/script/application.js",

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -84,6 +84,24 @@ module.exports = function (grunt) {
                 }]
             }
         },
+        bump: {
+          options: {
+            files: ['package.json', 'bower.json'],
+            updateConfigs: [],
+            commit: true,
+            commitMessage: 'Release v%VERSION%',
+            commitFiles: ['package.json', 'bower.json'],
+            createTag: true,
+            tagName: 'v%VERSION%',
+            tagMessage: 'Version %VERSION%',
+            push: true,
+            pushTo: 'origin',
+            gitDescribeOptions: '--tags --always --abbrev=1 --dirty=-d',
+            globalReplace: false,
+            prereleaseName: false,
+            regExp: false
+          }
+        },
         shell: {
             coverage: {
                 command: 'cd static/script-tests/jasmine; pwd; ./coverage.sh -p;'
@@ -113,6 +131,8 @@ module.exports = function (grunt) {
     grunt.loadNpmTasks('grunt-complexity');
     grunt.loadNpmTasks('grunt-text-replace');
     grunt.loadNpmTasks("grunt-shell");
+    grunt.loadNpmTasks('grunt-bump');
+
 
     grunt.registerTask("hint", ["jshint"]);
     grunt.registerTask("test", ["jasmine"]);
@@ -122,7 +142,7 @@ module.exports = function (grunt) {
     grunt.registerTask('default', 'full');
     grunt.registerTask("coverage", "Produce a coverage report of the main source files", ["jasmine:src:build", "shell:coverage"]);
     grunt.registerTask("spec", ["jasmine:src:build", "openspec"]);
-    
+
     grunt.registerTask("openspec", "Open the generated Jasmine spec file", function() {
         var childProcess = require('child_process');
         var outfile = grunt.config("jasmine.options.outfile");

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "bbc-fmtvp-tal",
   "version": "3.0.4",
+  "name": "tal",
   "repository": {
     "type": "git",
     "url": "https://github.com/fmtvp/tal.git"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "version": "3.0.4",
   "name": "tal",
+  "version": "3.0.4",
   "repository": {
     "type": "git",
     "url": "https://github.com/fmtvp/tal.git"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bbc-fmtvp-tal",
-  "version": "0.0.0",
+  "version": "3.0.4",
   "repository": {
     "type": "git",
     "url": "https://github.com/fmtvp/tal.git"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   "description": "Library for building applications for Connected TV devices",
   "devDependencies": {
     "exec-sync": "latest",
-    "grunt": "~0.4.1",
+    "grunt": "^0.4.5",
+    "grunt-bump": "^0.6.0",
     "grunt-cli": "~0.1.6",
     "grunt-contrib-jasmine": "~0.5.2",
     "grunt-contrib-jshint": "~0.10.0",


### PR DESCRIPTION
Grunt bump added as a dev-dependency.

Grunt bump allows the developer to easily keep versions of a package up to date and will also
create tags when a new version is to be created. 

This should simplify the update bower package version, update npm package version, tag, release
process to just grunt bump:\<type\> 
eg.
version/last tag: 3.0.4
```
grunt bump:patch
```
version/created tag: 3.0.5

grunt-bump documentation: https://www.npmjs.com/package/grunt-bump