### PR TITLE
Add license to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "tal",
+  "license": "Apache-2.0",
   "version": "3.0.4",
   "repository": {
     "type": "git",


### PR DESCRIPTION
The current package.json doesn't contain a reference to the license.