### PR TITLE
IPLAYERTVV1-3520 & IPLAYERTVV1-3521

### DIFF
--- a/static/script-tests/tests/devices/mediaplayer/live/restartable.js
+++ b/static/script-tests/tests/devices/mediaplayer/live/restartable.js
@@ -318,4 +318,31 @@
             clock.restore();
         }, config);
     };
+
+    this.LivePlayerSupportLevelRestartableTest.prototype.testAutoPlaysImmediatelyIfPausedAfterAlreadyAutoPlaying = function (queue) {
+        expectAsserts(1);
+        queuedApplicationInit(queue, 'lib/mockapplication', ["antie/devices/mediaplayer/mediaplayer", "antie/devices/device", "antie/devices/mediaplayer/live/restartable"], function (application, MediaPlayer, Device) {
+            var device = new Device(antie.framework.deviceConfiguration);
+            var livePlayer = device.getLivePlayer();
+
+            livePlayer._mediaPlayer.beginPlaybackFrom = this.sandbox.stub();
+            livePlayer._mediaPlayer.beginPlayback = this.sandbox.stub();
+            livePlayer._mediaPlayer.pause = this.sandbox.stub();
+            livePlayer._mediaPlayer.resume = this.sandbox.stub();
+
+            var clock = sinon.useFakeTimers();
+            livePlayer.beginPlaybackFrom(30);
+            livePlayer.pause();
+            clock.tick(30 * 1000);
+
+            livePlayer._mediaPlayer.resume.reset();
+
+            livePlayer.pause();
+            clock.tick(1);
+
+            assert(livePlayer._mediaPlayer.resume.called);
+
+            clock.restore();
+        }, config);
+    };
 })();

--- a/static/script-tests/tests/devices/mediaplayer/live/restartable.js
+++ b/static/script-tests/tests/devices/mediaplayer/live/restartable.js
@@ -280,6 +280,7 @@
             livePlayer._mediaPlayer.beginPlayback = this.sandbox.stub();
             livePlayer._mediaPlayer.pause = this.sandbox.stub();
             livePlayer._mediaPlayer.resume = this.sandbox.stub();
+            this.sandbox.stub(livePlayer._mediaPlayer, 'getState').returns(MediaPlayer.STATE.PLAYING);
 
             var clock = sinon.useFakeTimers();
             livePlayer.beginPlaybackFrom(30);
@@ -305,6 +306,7 @@
             livePlayer._mediaPlayer.beginPlayback = this.sandbox.stub();
             livePlayer._mediaPlayer.pause = this.sandbox.stub();
             livePlayer._mediaPlayer.resume = this.sandbox.stub();
+            this.sandbox.stub(livePlayer._mediaPlayer, 'getState').returns(MediaPlayer.STATE.PLAYING);
 
             var clock = sinon.useFakeTimers();
             livePlayer.beginPlaybackFrom(30);
@@ -345,4 +347,37 @@
             clock.restore();
         }, config);
     };
+
+    this.LivePlayerSupportLevelRestartableTest.prototype.testAfterPausedEventWithPausedStateDoesNotCancelAutoPlay = function (queue) {
+        expectAsserts(1);
+        queuedApplicationInit(queue, 'lib/mockapplication', ["antie/devices/mediaplayer/mediaplayer", "antie/devices/device", "antie/devices/mediaplayer/live/seekable"], function (application, MediaPlayer, Device) {
+            var device = new Device(antie.framework.deviceConfiguration);
+            var livePlayer = device.getLivePlayer();
+            this.sandbox.stub(livePlayer._mediaPlayer, 'pause');
+
+            var expectedRange = {
+                "start": 0,
+                "end": 30
+            };
+
+            this.sandbox.stub(livePlayer._mediaPlayer, 'getSeekableRange').returns(expectedRange);
+            this.sandbox.stub(livePlayer._mediaPlayer, 'getCurrentTime').returns(30);
+            livePlayer._mediaPlayer.getState = this.sandbox.stub();
+            livePlayer._mediaPlayer.getState.returns(MediaPlayer.STATE.PLAYING);
+
+            livePlayer._mediaPlayer.resume = this.sandbox.stub();
+
+            var clock = sinon.useFakeTimers();
+            livePlayer.pause();
+
+            livePlayer._mediaPlayer.getState.returns(MediaPlayer.STATE.PAUSED);
+            livePlayer._mediaPlayer._emitEvent(MediaPlayer.EVENT.SENTINEL_PAUSE);
+            clock.tick(30 * 1000);
+
+            assert(livePlayer._mediaPlayer.resume.called);
+
+            clock.restore();
+        }, config);
+    };
+
 })();

--- a/static/script-tests/tests/devices/mediaplayer/live/restartable.js
+++ b/static/script-tests/tests/devices/mediaplayer/live/restartable.js
@@ -233,12 +233,9 @@
             livePlayer._mediaPlayer.beginPlayback = this.sandbox.stub();
             livePlayer._mediaPlayer.pause = this.sandbox.stub();
             livePlayer._mediaPlayer.resume = this.sandbox.stub();
-            this.sandbox.stub(livePlayer._mediaPlayer, 'getCurrentTime').returns(30);
-            this.sandbox.stub(livePlayer._mediaPlayer, 'getState').returns(MediaPlayer.STATE.PLAYING);
 
             var clock = sinon.useFakeTimers();
             livePlayer.beginPlaybackFrom(30);
-            livePlayer._mediaPlayer._emitEvent(MediaPlayer.EVENT.PLAYING);
             livePlayer.pause();
             clock.tick(30 * 1000);
 
@@ -283,12 +280,9 @@
             livePlayer._mediaPlayer.beginPlayback = this.sandbox.stub();
             livePlayer._mediaPlayer.pause = this.sandbox.stub();
             livePlayer._mediaPlayer.resume = this.sandbox.stub();
-            this.sandbox.stub(livePlayer._mediaPlayer, 'getCurrentTime').returns(30);
-            this.sandbox.stub(livePlayer._mediaPlayer, 'getState').returns(MediaPlayer.STATE.PLAYING);
 
             var clock = sinon.useFakeTimers();
-            livePlayer.beginPlayback();
-            livePlayer._mediaPlayer._emitEvent(MediaPlayer.EVENT.PLAYING);
+            livePlayer.beginPlaybackFrom(30);
             livePlayer.pause();
             clock.tick(15 * 1000);
             livePlayer._mediaPlayer._emitEvent(MediaPlayer.EVENT.PLAYING);
@@ -311,13 +305,9 @@
             livePlayer._mediaPlayer.beginPlayback = this.sandbox.stub();
             livePlayer._mediaPlayer.pause = this.sandbox.stub();
             livePlayer._mediaPlayer.resume = this.sandbox.stub();
-            this.sandbox.stub(livePlayer._mediaPlayer, 'getCurrentTime').returns(30);
-            this.sandbox.stub(livePlayer._mediaPlayer, 'getState').returns(MediaPlayer.STATE.PLAYING);
 
             var clock = sinon.useFakeTimers();
             livePlayer.beginPlaybackFrom(30);
-            livePlayer._mediaPlayer._emitEvent(MediaPlayer.EVENT.PLAYING);
-
             livePlayer.pause();
 
             livePlayer._mediaPlayer._emitEvent(MediaPlayer.EVENT.PLAYING);

--- a/static/script-tests/tests/devices/mediaplayer/live/restartable.js
+++ b/static/script-tests/tests/devices/mediaplayer/live/restartable.js
@@ -223,7 +223,7 @@
         }, config);
     };
 
-    this.LivePlayerSupportLevelRestartableTest.prototype.testAutoPlayWhenBeginPlaybackFromThenPausedAndStartOfRangeIsReached = function (queue) {
+    this.LivePlayerSupportLevelRestartableTest.prototype.testAutoResumeWhenBeginPlaybackFromThenPausedAndStartOfRangeIsReached = function (queue) {
         expectAsserts(1);
         queuedApplicationInit(queue, 'lib/mockapplication', ["antie/devices/mediaplayer/mediaplayer", "antie/devices/device", "antie/devices/mediaplayer/live/restartable"], function (application, MediaPlayer, Device) {
             var device = new Device(antie.framework.deviceConfiguration);
@@ -245,7 +245,7 @@
         }, config);
     };
 
-    this.LivePlayerSupportLevelRestartableTest.prototype.testAutoPlayWhenBeginPlaybackThenPausedAndStartOfRangeIsReached = function (queue) {
+    this.LivePlayerSupportLevelRestartableTest.prototype.testAutoResumeWhenBeginPlaybackThenPausedAndStartOfRangeIsReached = function (queue) {
         expectAsserts(1);
         queuedApplicationInit(queue, 'lib/mockapplication', ["antie/devices/mediaplayer/mediaplayer", "antie/devices/device", "antie/devices/mediaplayer/live/restartable"], function (application, MediaPlayer, Device) {
             var device = new Device(antie.framework.deviceConfiguration);
@@ -270,7 +270,7 @@
         }, config);
     };
 
-    this.LivePlayerSupportLevelRestartableTest.prototype.testAutoPlayWhenPausedMultipleTimesAndStartOfRangeIsReached = function (queue) {
+    this.LivePlayerSupportLevelRestartableTest.prototype.testAutoResumeWhenPausedMultipleTimesAndStartOfRangeIsReached = function (queue) {
         expectAsserts(1);
         queuedApplicationInit(queue, 'lib/mockapplication', ["antie/devices/mediaplayer/mediaplayer", "antie/devices/device", "antie/devices/mediaplayer/live/restartable"], function (application, MediaPlayer, Device) {
             var device = new Device(antie.framework.deviceConfiguration);
@@ -296,7 +296,7 @@
         }, config);
     };
 
-    this.LivePlayerSupportLevelRestartableTest.prototype.testAutoPlayCancelledWhenPausedAndResumedBeforeStartOfRangeIsReached = function (queue) {
+    this.LivePlayerSupportLevelRestartableTest.prototype.testAutoResumeCancelledWhenPausedAndResumedBeforeStartOfRangeIsReached = function (queue) {
         expectAsserts(1);
         queuedApplicationInit(queue, 'lib/mockapplication', ["antie/devices/mediaplayer/mediaplayer", "antie/devices/device", "antie/devices/mediaplayer/live/restartable"], function (application, MediaPlayer, Device) {
             var device = new Device(antie.framework.deviceConfiguration);
@@ -321,7 +321,7 @@
         }, config);
     };
 
-    this.LivePlayerSupportLevelRestartableTest.prototype.testAutoPlaysImmediatelyIfPausedAfterAlreadyAutoPlaying = function (queue) {
+    this.LivePlayerSupportLevelRestartableTest.prototype.testAutoResumesImmediatelyIfPausedAfterAlreadyAutoResumeing = function (queue) {
         expectAsserts(1);
         queuedApplicationInit(queue, 'lib/mockapplication', ["antie/devices/mediaplayer/mediaplayer", "antie/devices/device", "antie/devices/mediaplayer/live/restartable"], function (application, MediaPlayer, Device) {
             var device = new Device(antie.framework.deviceConfiguration);
@@ -348,7 +348,7 @@
         }, config);
     };
 
-    this.LivePlayerSupportLevelRestartableTest.prototype.testAutoPlayNotCancelledByEventWithPausedState = function (queue) {
+    this.LivePlayerSupportLevelRestartableTest.prototype.testAutoResumeNotCancelledByEventWithPausedState = function (queue) {
         expectAsserts(1);
         queuedApplicationInit(queue, 'lib/mockapplication', ["antie/devices/mediaplayer/mediaplayer", "antie/devices/device", "antie/devices/mediaplayer/live/restartable"], function (application, MediaPlayer, Device) {
             var device = new Device(antie.framework.deviceConfiguration);
@@ -376,7 +376,7 @@
         }, config);
     };
 
-    this.LivePlayerSupportLevelRestartableTest.prototype.testAutoPlayWhenBeginPlaybackFromTimeSpentBufferingIsDeducted = function (queue) {
+    this.LivePlayerSupportLevelRestartableTest.prototype.testAutoResumeWhenBeginPlaybackFromTimeSpentBufferingIsDeducted = function (queue) {
         expectAsserts(1);
         queuedApplicationInit(queue, 'lib/mockapplication', ["antie/devices/mediaplayer/mediaplayer", "antie/devices/device", "antie/devices/mediaplayer/live/restartable"], function (application, MediaPlayer, Device) {
             var device = new Device(antie.framework.deviceConfiguration);
@@ -410,7 +410,7 @@
         }, config);
     };
 
-    this.LivePlayerSupportLevelRestartableTest.prototype.testAutoPlayWhenBeginPlaybackTimeSpentBufferingIsDeducted = function (queue) {
+    this.LivePlayerSupportLevelRestartableTest.prototype.testAutoResumeWhenBeginPlaybackTimeSpentBufferingIsDeducted = function (queue) {
         expectAsserts(1);
         queuedApplicationInit(queue, 'lib/mockapplication', ["antie/devices/mediaplayer/mediaplayer", "antie/devices/device", "antie/devices/mediaplayer/live/restartable"], function (application, MediaPlayer, Device) {
             var device = new Device(antie.framework.deviceConfiguration);

--- a/static/script-tests/tests/devices/mediaplayer/live/restartable.js
+++ b/static/script-tests/tests/devices/mediaplayer/live/restartable.js
@@ -233,9 +233,12 @@
             livePlayer._mediaPlayer.beginPlayback = this.sandbox.stub();
             livePlayer._mediaPlayer.pause = this.sandbox.stub();
             livePlayer._mediaPlayer.resume = this.sandbox.stub();
+            this.sandbox.stub(livePlayer._mediaPlayer, 'getCurrentTime').returns(30);
+            this.sandbox.stub(livePlayer._mediaPlayer, 'getState').returns(MediaPlayer.STATE.PLAYING);
 
             var clock = sinon.useFakeTimers();
             livePlayer.beginPlaybackFrom(30);
+            livePlayer._mediaPlayer._emitEvent(MediaPlayer.EVENT.PLAYING);
             livePlayer.pause();
             clock.tick(30 * 1000);
 
@@ -280,9 +283,12 @@
             livePlayer._mediaPlayer.beginPlayback = this.sandbox.stub();
             livePlayer._mediaPlayer.pause = this.sandbox.stub();
             livePlayer._mediaPlayer.resume = this.sandbox.stub();
+            this.sandbox.stub(livePlayer._mediaPlayer, 'getCurrentTime').returns(30);
+            this.sandbox.stub(livePlayer._mediaPlayer, 'getState').returns(MediaPlayer.STATE.PLAYING);
 
             var clock = sinon.useFakeTimers();
-            livePlayer.beginPlaybackFrom(30);
+            livePlayer.beginPlayback();
+            livePlayer._mediaPlayer._emitEvent(MediaPlayer.EVENT.PLAYING);
             livePlayer.pause();
             clock.tick(15 * 1000);
             livePlayer._mediaPlayer._emitEvent(MediaPlayer.EVENT.PLAYING);
@@ -305,9 +311,13 @@
             livePlayer._mediaPlayer.beginPlayback = this.sandbox.stub();
             livePlayer._mediaPlayer.pause = this.sandbox.stub();
             livePlayer._mediaPlayer.resume = this.sandbox.stub();
+            this.sandbox.stub(livePlayer._mediaPlayer, 'getCurrentTime').returns(30);
+            this.sandbox.stub(livePlayer._mediaPlayer, 'getState').returns(MediaPlayer.STATE.PLAYING);
 
             var clock = sinon.useFakeTimers();
             livePlayer.beginPlaybackFrom(30);
+            livePlayer._mediaPlayer._emitEvent(MediaPlayer.EVENT.PLAYING);
+
             livePlayer.pause();
 
             livePlayer._mediaPlayer._emitEvent(MediaPlayer.EVENT.PLAYING);

--- a/static/script-tests/tests/devices/mediaplayer/live/restartable.js
+++ b/static/script-tests/tests/devices/mediaplayer/live/restartable.js
@@ -89,8 +89,12 @@
 
     this.LivePlayerSupportLevelRestartableTest.prototype.testLivePlayerGetPlayerElementCallsFunctionInMediaPlayer = testFunctionsInLivePlayerCallMediaPlayerFunctions('getPlayerElement', 0);
 
+    this.LivePlayerSupportLevelRestartableTest.prototype.testLivePlayerPauseCallsFunctionInMediaPlayer = testFunctionsInLivePlayerCallMediaPlayerFunctions('pause', 0);
+
+    this.LivePlayerSupportLevelRestartableTest.prototype.testLivePlayerResumeCallsFunctionInMediaPlayer = testFunctionsInLivePlayerCallMediaPlayerFunctions('resume', 0);
+
     this.LivePlayerSupportLevelRestartableTest.prototype.testSeekableMediaPlayerFunctionsNotDefinedInRestartableLive = function (queue) {
-        expectAsserts(5);
+        expectAsserts(3);
 
         queuedApplicationInit(queue, 'lib/mockapplication', ["antie/devices/mediaplayer/mediaplayer", "antie/devices/device", "antie/devices/mediaplayer/live/restartable"], function(application, MediaPlayer, Device) {
 
@@ -98,8 +102,6 @@
             var livePlayer = device.getLivePlayer();
 
             assertUndefined(livePlayer.playFrom);
-            assertUndefined(livePlayer.pause);
-            assertUndefined(livePlayer.resume);
             assertUndefined(livePlayer.getCurrentTime);
             assertUndefined(livePlayer.getSeekableRange);
         });

--- a/static/script-tests/tests/devices/mediaplayer/live/restartable.js
+++ b/static/script-tests/tests/devices/mediaplayer/live/restartable.js
@@ -350,24 +350,20 @@
 
     this.LivePlayerSupportLevelRestartableTest.prototype.testAfterPausedEventWithPausedStateDoesNotCancelAutoPlay = function (queue) {
         expectAsserts(1);
-        queuedApplicationInit(queue, 'lib/mockapplication', ["antie/devices/mediaplayer/mediaplayer", "antie/devices/device", "antie/devices/mediaplayer/live/seekable"], function (application, MediaPlayer, Device) {
+        queuedApplicationInit(queue, 'lib/mockapplication', ["antie/devices/mediaplayer/mediaplayer", "antie/devices/device", "antie/devices/mediaplayer/live/restartable"], function (application, MediaPlayer, Device) {
             var device = new Device(antie.framework.deviceConfiguration);
             var livePlayer = device.getLivePlayer();
-            this.sandbox.stub(livePlayer._mediaPlayer, 'pause');
 
-            var expectedRange = {
-                "start": 0,
-                "end": 30
-            };
-
-            this.sandbox.stub(livePlayer._mediaPlayer, 'getSeekableRange').returns(expectedRange);
-            this.sandbox.stub(livePlayer._mediaPlayer, 'getCurrentTime').returns(30);
+            livePlayer._mediaPlayer.beginPlaybackFrom = this.sandbox.stub();
+            livePlayer._mediaPlayer.beginPlayback = this.sandbox.stub();
+            livePlayer._mediaPlayer.pause = this.sandbox.stub();
+            livePlayer._mediaPlayer.resume = this.sandbox.stub();
             livePlayer._mediaPlayer.getState = this.sandbox.stub();
             livePlayer._mediaPlayer.getState.returns(MediaPlayer.STATE.PLAYING);
-
             livePlayer._mediaPlayer.resume = this.sandbox.stub();
 
             var clock = sinon.useFakeTimers();
+            livePlayer.beginPlaybackFrom(30);
             livePlayer.pause();
 
             livePlayer._mediaPlayer.getState.returns(MediaPlayer.STATE.PAUSED);

--- a/static/script-tests/tests/devices/mediaplayer/live/seekable.js
+++ b/static/script-tests/tests/devices/mediaplayer/live/seekable.js
@@ -94,14 +94,6 @@
             queuedApplicationInit(queue, 'lib/mockapplication', ["antie/devices/mediaplayer/mediaplayer", "antie/devices/device", "antie/devices/mediaplayer/live/seekable"], function (application, MediaPlayer, Device) {
                 var device = new Device(antie.framework.deviceConfiguration);
                 var livePlayer = device.getLivePlayer();
-                if (action === 'pause') {
-                    var expectedRange = {
-                        "start": 0,
-                        "end": 30
-                    };
-                    this.sandbox.stub(livePlayer._mediaPlayer, 'getSeekableRange').returns(expectedRange);
-                    this.sandbox.stub(livePlayer._mediaPlayer, 'getCurrentTime').returns(30);
-                }
                 var mediaPlayerFuncStub = this.sandbox.stub();
                 device.getMediaPlayer()[action] = mediaPlayerFuncStub;
                 livePlayer[action]();
@@ -148,11 +140,10 @@
             this.sandbox.stub(livePlayer._mediaPlayer, 'getCurrentTime').returns(30);
             this.sandbox.stub(livePlayer._mediaPlayer, 'resume');
             var mediaPlayerFuncStub = this.sandbox.stub();
-            device.getMediaPlayer()['pause'] = mediaPlayerFuncStub;
-            //using fake timers to ensure auto play timer fires
+            device.getMediaPlayer().pause = mediaPlayerFuncStub;
+            //using fake timers to ensure auto play timer does not fire
             var clock = sinon.useFakeTimers();
-            livePlayer['pause']();
-            clock.tick(30*1000);
+            livePlayer.pause();
             assert(mediaPlayerFuncStub.calledOnce);
             assertEquals(0, mediaPlayerFuncStub.getCall(0).args.length);
             clock.restore();
@@ -309,7 +300,7 @@
         }, config);
     };
 
-    this.LivePlayerSupportLevelSeekableTest.prototype.testResumeIsCalledWhenPausedAndStartOfRangeIsReached = function (queue) {
+    this.LivePlayerSupportLevelSeekableTest.prototype.testAutoPlayWhenPausedAndStartOfRangeIsReached = function (queue) {
         expectAsserts(1);
         queuedApplicationInit(queue, 'lib/mockapplication', ["antie/devices/mediaplayer/mediaplayer", "antie/devices/device", "antie/devices/mediaplayer/live/seekable"], function (application, MediaPlayer, Device) {
             var device = new Device(antie.framework.deviceConfiguration);

--- a/static/script-tests/tests/devices/mediaplayer/live/seekable.js
+++ b/static/script-tests/tests/devices/mediaplayer/live/seekable.js
@@ -34,14 +34,52 @@
         this.sandbox.restore();
     };
 
-    var config = {"modules":{"base":"antie/devices/browserdevice","modifiers":["antie/devices/mediaplayer/html5"]}, "input":{"map":{}},"layouts":[{"width":960,"height":540,"module":"fixtures/layouts/default","classes":["browserdevice540p"]}],"deviceConfigurationKey":"devices-html5-1"};
-    var configWithForceBeginPlaybackToEndOfWindowAsTrue = {"modules":{"base":"antie/devices/browserdevice","modifiers":["antie/devices/mediaplayer/html5"]}, "input":{"map":{}},"layouts":[{"width":960,"height":540,"module":"fixtures/layouts/default","classes":["browserdevice540p"]}],"deviceConfigurationKey":"devices-html5-1","streaming":{"overrides":{"forceBeginPlaybackToEndOfWindow":true}}};
-    var configWithForceBeginPlaybackToEndOfWindowAsFalse = {"modules":{"base":"antie/devices/browserdevice","modifiers":["antie/devices/mediaplayer/html5"]}, "input":{"map":{}},"layouts":[{"width":960,"height":540,"module":"fixtures/layouts/default","classes":["browserdevice540p"]}],"deviceConfigurationKey":"devices-html5-1","streaming":{"overrides":{"forceBeginPlaybackToEndOfWindow":false}}};
+    var config = {
+        "modules": {"base": "antie/devices/browserdevice", "modifiers": ["antie/devices/mediaplayer/html5"]},
+        "input": {"map": {}},
+        "layouts": [{
+            "width": 960,
+            "height": 540,
+            "module": "fixtures/layouts/default",
+            "classes": ["browserdevice540p"]
+        }],
+        "deviceConfigurationKey": "devices-html5-1"
+    };
+    var configWithForceBeginPlaybackToEndOfWindowAsTrue = {
+        "modules": {
+            "base": "antie/devices/browserdevice",
+            "modifiers": ["antie/devices/mediaplayer/html5"]
+        },
+        "input": {"map": {}},
+        "layouts": [{
+            "width": 960,
+            "height": 540,
+            "module": "fixtures/layouts/default",
+            "classes": ["browserdevice540p"]
+        }],
+        "deviceConfigurationKey": "devices-html5-1",
+        "streaming": {"overrides": {"forceBeginPlaybackToEndOfWindow": true}}
+    };
+    var configWithForceBeginPlaybackToEndOfWindowAsFalse = {
+        "modules": {
+            "base": "antie/devices/browserdevice",
+            "modifiers": ["antie/devices/mediaplayer/html5"]
+        },
+        "input": {"map": {}},
+        "layouts": [{
+            "width": 960,
+            "height": 540,
+            "module": "fixtures/layouts/default",
+            "classes": ["browserdevice540p"]
+        }],
+        "deviceConfigurationKey": "devices-html5-1",
+        "streaming": {"overrides": {"forceBeginPlaybackToEndOfWindow": false}}
+    };
 
     this.LivePlayerSupportLevelSeekableTest.prototype.testGetLiveSupportReturnsSeekableWithSupportLevelSeekable = function (queue) {
         expectAsserts(1);
 
-        queuedApplicationInit(queue, 'lib/mockapplication', ["antie/devices/mediaplayer/mediaplayer", "antie/devices/device", "antie/devices/mediaplayer/live/seekable"], function(application, MediaPlayer, Device) {
+        queuedApplicationInit(queue, 'lib/mockapplication', ["antie/devices/mediaplayer/mediaplayer", "antie/devices/device", "antie/devices/mediaplayer/live/seekable"], function (application, MediaPlayer, Device) {
 
             var device = new Device(antie.framework.deviceConfiguration);
             var liveSupportLevel = device.getLiveSupport();
@@ -50,12 +88,20 @@
         });
     };
 
-    var testFunctionsInLivePlayerCallMediaPlayerFunctions = function(action, expectedArgCount) {
+    var testFunctionsInLivePlayerCallMediaPlayerFunctions = function (action, expectedArgCount) {
         return function (queue) {
             expectAsserts(2);
-            queuedApplicationInit(queue, 'lib/mockapplication', ["antie/devices/mediaplayer/mediaplayer", "antie/devices/device", "antie/devices/mediaplayer/live/seekable"], function(application, MediaPlayer, Device) {
+            queuedApplicationInit(queue, 'lib/mockapplication', ["antie/devices/mediaplayer/mediaplayer", "antie/devices/device", "antie/devices/mediaplayer/live/seekable"], function (application, MediaPlayer, Device) {
                 var device = new Device(antie.framework.deviceConfiguration);
                 var livePlayer = device.getLivePlayer();
+                if (action === 'pause') {
+                    var expectedRange = {
+                        "start": 0,
+                        "end": 30
+                    };
+                    this.sandbox.stub(livePlayer._mediaPlayer, 'getSeekableRange').returns(expectedRange);
+                    this.sandbox.stub(livePlayer._mediaPlayer, 'getCurrentTime').returns(30);
+                }
                 var mediaPlayerFuncStub = this.sandbox.stub();
                 device.getMediaPlayer()[action] = mediaPlayerFuncStub;
                 livePlayer[action]();
@@ -89,7 +135,29 @@
 
     this.LivePlayerSupportLevelSeekableTest.prototype.testSeekableLivePlayerPlayFromCallsFunctionInMediaPlayer = testFunctionsInLivePlayerCallMediaPlayerFunctions('playFrom', 1);
 
-    this.LivePlayerSupportLevelSeekableTest.prototype.testSeekableLivePlayerPauseCallsFunctionInMediaPlayer = testFunctionsInLivePlayerCallMediaPlayerFunctions('pause', 0);
+    this.LivePlayerSupportLevelSeekableTest.prototype.testSeekableLivePlayerPauseCallsFunctionInMediaPlayer = function (queue) {
+        expectAsserts(2);
+        queuedApplicationInit(queue, 'lib/mockapplication', ["antie/devices/mediaplayer/mediaplayer", "antie/devices/device", "antie/devices/mediaplayer/live/seekable"], function (application, MediaPlayer, Device) {
+            var device = new Device(antie.framework.deviceConfiguration);
+            var livePlayer = device.getLivePlayer();
+            var expectedRange = {
+                "start": 0,
+                "end": 30
+            };
+            this.sandbox.stub(livePlayer._mediaPlayer, 'getSeekableRange').returns(expectedRange);
+            this.sandbox.stub(livePlayer._mediaPlayer, 'getCurrentTime').returns(30);
+            this.sandbox.stub(livePlayer._mediaPlayer, 'resume');
+            var mediaPlayerFuncStub = this.sandbox.stub();
+            device.getMediaPlayer()['pause'] = mediaPlayerFuncStub;
+            //using fake timers to ensure auto play timer fires
+            var clock = sinon.useFakeTimers();
+            livePlayer['pause']();
+            clock.tick(30*1000);
+            assert(mediaPlayerFuncStub.calledOnce);
+            assertEquals(0, mediaPlayerFuncStub.getCall(0).args.length);
+            clock.restore();
+        }, config);
+    };
 
     this.LivePlayerSupportLevelSeekableTest.prototype.testSeekableLivePlayerResumeCallsFunctionInMediaPlayer = testFunctionsInLivePlayerCallMediaPlayerFunctions('resume', 0);
 
@@ -101,7 +169,7 @@
 
     this.LivePlayerSupportLevelSeekableTest.prototype.testGetStateReturnsState = function (queue) {
         expectAsserts(1);
-        queuedApplicationInit(queue, 'lib/mockapplication', ["antie/devices/mediaplayer/mediaplayer", "antie/devices/device", "antie/devices/mediaplayer/live/seekable"], function(application, MediaPlayer, Device) {
+        queuedApplicationInit(queue, 'lib/mockapplication', ["antie/devices/mediaplayer/mediaplayer", "antie/devices/device", "antie/devices/mediaplayer/live/seekable"], function (application, MediaPlayer, Device) {
             var device = new Device(antie.framework.deviceConfiguration);
             var livePlayer = device.getLivePlayer();
             assertEquals("EMPTY", livePlayer.getState());
@@ -110,7 +178,7 @@
 
     this.LivePlayerSupportLevelSeekableTest.prototype.testGetSourceReturnsSource = function (queue) {
         expectAsserts(1);
-        queuedApplicationInit(queue, 'lib/mockapplication', ["antie/devices/mediaplayer/mediaplayer", "antie/devices/device", "antie/devices/mediaplayer/live/seekable"], function(application, MediaPlayer, Device) {
+        queuedApplicationInit(queue, 'lib/mockapplication', ["antie/devices/mediaplayer/mediaplayer", "antie/devices/device", "antie/devices/mediaplayer/live/seekable"], function (application, MediaPlayer, Device) {
             var device = new Device(antie.framework.deviceConfiguration);
             var livePlayer = device.getLivePlayer();
 
@@ -122,7 +190,7 @@
 
     this.LivePlayerSupportLevelSeekableTest.prototype.testGetMimeTypeReturnsMimeType = function (queue) {
         expectAsserts(1);
-        queuedApplicationInit(queue, 'lib/mockapplication', ["antie/devices/mediaplayer/mediaplayer", "antie/devices/device", "antie/devices/mediaplayer/live/seekable"], function(application, MediaPlayer, Device) {
+        queuedApplicationInit(queue, 'lib/mockapplication', ["antie/devices/mediaplayer/mediaplayer", "antie/devices/device", "antie/devices/mediaplayer/live/seekable"], function (application, MediaPlayer, Device) {
             var device = new Device(antie.framework.deviceConfiguration);
             var livePlayer = device.getLivePlayer();
 
@@ -134,7 +202,7 @@
 
     this.LivePlayerSupportLevelSeekableTest.prototype.testGetCurrentTimeReturnsCurrentTime = function (queue) {
         expectAsserts(1);
-        queuedApplicationInit(queue, 'lib/mockapplication', ["antie/devices/mediaplayer/mediaplayer", "antie/devices/device", "antie/devices/mediaplayer/live/seekable"], function(application, MediaPlayer, Device) {
+        queuedApplicationInit(queue, 'lib/mockapplication', ["antie/devices/mediaplayer/mediaplayer", "antie/devices/device", "antie/devices/mediaplayer/live/seekable"], function (application, MediaPlayer, Device) {
             var device = new Device(antie.framework.deviceConfiguration);
             var livePlayer = device.getLivePlayer();
 
@@ -146,7 +214,7 @@
 
     this.LivePlayerSupportLevelSeekableTest.prototype.testGetSeekableRangeReturnsSeekableRange = function (queue) {
         expectAsserts(1);
-        queuedApplicationInit(queue, 'lib/mockapplication', ["antie/devices/mediaplayer/mediaplayer", "antie/devices/device", "antie/devices/mediaplayer/live/seekable"], function(application, MediaPlayer, Device) {
+        queuedApplicationInit(queue, 'lib/mockapplication', ["antie/devices/mediaplayer/mediaplayer", "antie/devices/device", "antie/devices/mediaplayer/live/seekable"], function (application, MediaPlayer, Device) {
             var device = new Device(antie.framework.deviceConfiguration);
             var livePlayer = device.getLivePlayer();
 
@@ -161,7 +229,7 @@
         }, config);
     };
 
-    this.LivePlayerSupportLevelSeekableTest.prototype.testMediaTypeIsMutatedToLive = function(queue) {
+    this.LivePlayerSupportLevelSeekableTest.prototype.testMediaTypeIsMutatedToLive = function (queue) {
         expectAsserts(4);
         queuedApplicationInit(queue, 'lib/mockapplication', ["antie/devices/mediaplayer/mediaplayer", "antie/devices/device", "antie/devices/mediaplayer/live/seekable"], function (application, MediaPlayer, Device) {
             var device = new Device(antie.framework.deviceConfiguration);
@@ -240,4 +308,61 @@
             assert(livePlayer._mediaPlayer.beginPlaybackFrom.notCalled);
         }, config);
     };
+
+    this.LivePlayerSupportLevelSeekableTest.prototype.testResumeIsCalledWhenPausedAndStartOfRangeIsReached = function (queue) {
+        expectAsserts(1);
+        queuedApplicationInit(queue, 'lib/mockapplication', ["antie/devices/mediaplayer/mediaplayer", "antie/devices/device", "antie/devices/mediaplayer/live/seekable"], function (application, MediaPlayer, Device) {
+            var device = new Device(antie.framework.deviceConfiguration);
+            var livePlayer = device.getLivePlayer();
+            this.sandbox.stub(livePlayer._mediaPlayer, 'pause');
+
+            var expectedRange = {
+                "start": 0,
+                "end": 30
+            };
+
+            this.sandbox.stub(livePlayer._mediaPlayer, 'getSeekableRange').returns(expectedRange);
+            this.sandbox.stub(livePlayer._mediaPlayer, 'getCurrentTime').returns(30);
+
+            livePlayer._mediaPlayer.resume = this.sandbox.stub();
+
+            var clock = sinon.useFakeTimers();
+            livePlayer.pause();
+            clock.tick(30 * 1000);
+
+            assert(livePlayer._mediaPlayer.resume.called);
+
+            clock.restore();
+        }, config);
+    };
+
+    this.LivePlayerSupportLevelSeekableTest.prototype.testNoAutoPlayWhenPausedAndResumedBeforeStartOfRangeIsReached = function (queue) {
+        expectAsserts(1);
+        queuedApplicationInit(queue, 'lib/mockapplication', ["antie/devices/mediaplayer/mediaplayer", "antie/devices/device", "antie/devices/mediaplayer/live/seekable"], function (application, MediaPlayer, Device) {
+            var device = new Device(antie.framework.deviceConfiguration);
+            var livePlayer = device.getLivePlayer();
+            this.sandbox.stub(livePlayer._mediaPlayer, 'pause');
+
+            var expectedRange = {
+                "start": 0,
+                "end": 30
+            };
+
+            this.sandbox.stub(livePlayer._mediaPlayer, 'getSeekableRange').returns(expectedRange);
+            this.sandbox.stub(livePlayer._mediaPlayer, 'getCurrentTime').returns(30);
+
+            livePlayer._mediaPlayer.resume = this.sandbox.stub();
+
+            var clock = sinon.useFakeTimers();
+            livePlayer.pause();
+
+            livePlayer._mediaPlayer._emitEvent(MediaPlayer.EVENT.PLAYING);
+            clock.tick(30 * 1000);
+
+            assert(livePlayer._mediaPlayer.resume.notCalled);
+
+            clock.restore();
+        }, config);
+    };
+
 })();

--- a/static/script-tests/tests/devices/mediaplayer/live/seekable.js
+++ b/static/script-tests/tests/devices/mediaplayer/live/seekable.js
@@ -300,7 +300,7 @@
         }, config);
     };
 
-    this.LivePlayerSupportLevelSeekableTest.prototype.testAutoPlayWhenPausedAndStartOfRangeIsReached = function (queue) {
+    this.LivePlayerSupportLevelSeekableTest.prototype.testAutoResumeWhenPausedAndStartOfRangeIsReached = function (queue) {
         expectAsserts(1);
         queuedApplicationInit(queue, 'lib/mockapplication', ["antie/devices/mediaplayer/mediaplayer", "antie/devices/device", "antie/devices/mediaplayer/live/seekable"], function (application, MediaPlayer, Device) {
             var device = new Device(antie.framework.deviceConfiguration);
@@ -327,7 +327,7 @@
         }, config);
     };
 
-    this.LivePlayerSupportLevelSeekableTest.prototype.testNoAutoPlayWhenPausedAndResumedBeforeStartOfRangeIsReached = function (queue) {
+    this.LivePlayerSupportLevelSeekableTest.prototype.testAutoResumeCancelledWhenPausedAndResumedBeforeStartOfRangeIsReached = function (queue) {
         expectAsserts(1);
         queuedApplicationInit(queue, 'lib/mockapplication', ["antie/devices/mediaplayer/mediaplayer", "antie/devices/device", "antie/devices/mediaplayer/live/seekable"], function (application, MediaPlayer, Device) {
             var device = new Device(antie.framework.deviceConfiguration);
@@ -358,7 +358,7 @@
         }, config);
     };
 
-    this.LivePlayerSupportLevelSeekableTest.prototype.testAfterPausedAnEventWithPausedStateDoesNotCancelAutoPlay = function (queue) {
+    this.LivePlayerSupportLevelSeekableTest.prototype.testAutoResumeNotCancelledByEventWithPausedState = function (queue) {
         expectAsserts(1);
         queuedApplicationInit(queue, 'lib/mockapplication', ["antie/devices/mediaplayer/mediaplayer", "antie/devices/device", "antie/devices/mediaplayer/live/seekable"], function (application, MediaPlayer, Device) {
             var device = new Device(antie.framework.deviceConfiguration);

--- a/static/script-tests/tests/devices/mediaplayer/live/seekable.js
+++ b/static/script-tests/tests/devices/mediaplayer/live/seekable.js
@@ -341,6 +341,8 @@
 
             this.sandbox.stub(livePlayer._mediaPlayer, 'getSeekableRange').returns(expectedRange);
             this.sandbox.stub(livePlayer._mediaPlayer, 'getCurrentTime').returns(30);
+            livePlayer._mediaPlayer.getState = this.sandbox.stub();
+            livePlayer._mediaPlayer.getState.returns(MediaPlayer.STATE.PLAYING);
 
             livePlayer._mediaPlayer.resume = this.sandbox.stub();
 
@@ -351,6 +353,38 @@
             clock.tick(30 * 1000);
 
             assert(livePlayer._mediaPlayer.resume.notCalled);
+
+            clock.restore();
+        }, config);
+    };
+
+    this.LivePlayerSupportLevelSeekableTest.prototype.testAfterPausedAnEventWithPausedStateDoesNotCancelAutoPlay = function (queue) {
+        expectAsserts(1);
+        queuedApplicationInit(queue, 'lib/mockapplication', ["antie/devices/mediaplayer/mediaplayer", "antie/devices/device", "antie/devices/mediaplayer/live/seekable"], function (application, MediaPlayer, Device) {
+            var device = new Device(antie.framework.deviceConfiguration);
+            var livePlayer = device.getLivePlayer();
+            this.sandbox.stub(livePlayer._mediaPlayer, 'pause');
+
+            var expectedRange = {
+                "start": 0,
+                "end": 30
+            };
+
+            this.sandbox.stub(livePlayer._mediaPlayer, 'getSeekableRange').returns(expectedRange);
+            this.sandbox.stub(livePlayer._mediaPlayer, 'getCurrentTime').returns(30);
+            livePlayer._mediaPlayer.getState = this.sandbox.stub();
+            livePlayer._mediaPlayer.getState.returns(MediaPlayer.STATE.PLAYING);
+
+            livePlayer._mediaPlayer.resume = this.sandbox.stub();
+
+            var clock = sinon.useFakeTimers();
+            livePlayer.pause();
+
+            livePlayer._mediaPlayer.getState.returns(MediaPlayer.STATE.PAUSED);
+            livePlayer._mediaPlayer._emitEvent(MediaPlayer.EVENT.SENTINEL_PAUSE);
+            clock.tick(30 * 1000);
+
+            assert(livePlayer._mediaPlayer.resume.called);
 
             clock.restore();
         }, config);

--- a/static/script-tests/tests/devices/mediaplayer/live/seekable.js
+++ b/static/script-tests/tests/devices/mediaplayer/live/seekable.js
@@ -139,13 +139,12 @@
             this.sandbox.stub(livePlayer._mediaPlayer, 'getSeekableRange').returns(expectedRange);
             this.sandbox.stub(livePlayer._mediaPlayer, 'getCurrentTime').returns(30);
             this.sandbox.stub(livePlayer._mediaPlayer, 'resume');
-            var mediaPlayerFuncStub = this.sandbox.stub();
-            device.getMediaPlayer().pause = mediaPlayerFuncStub;
-            //using fake timers to ensure auto play timer does not fire
+            var pauseStub = this.sandbox.stub(device.getMediaPlayer(), 'pause');
+            //using fake timers to ensure auto resume timer does not fire
             var clock = sinon.useFakeTimers();
             livePlayer.pause();
-            assert(mediaPlayerFuncStub.calledOnce);
-            assertEquals(0, mediaPlayerFuncStub.getCall(0).args.length);
+            assert(pauseStub.calledOnce);
+            assertEquals(0, pauseStub.getCall(0).args.length);
             clock.restore();
         }, config);
     };

--- a/static/script/devices/mediaplayer/live/restartable.js
+++ b/static/script/devices/mediaplayer/live/restartable.js
@@ -86,7 +86,7 @@ require.def(
 
             pause: function () {
                 this._mediaPlayer.pause();
-                this._autoPlayAtStartOfRange();
+                this._autoResumeAtStartOfRange();
             },
 
             resume: function () {
@@ -147,11 +147,11 @@ require.def(
                 }
             },
 
-            _autoPlayAtStartOfRange: function () {
+            _autoResumeAtStartOfRange: function () {
                 var self = this;
                 if (this._timeUntilStartOfWindow !== null) {
                     var pauseStarted = new Date().getTime();
-                    var autoPlayTimer = setTimeout(function () {
+                    var autoResumeTimer = setTimeout(function () {
                         self.removeEventCallback(self, detectIfUnpaused);
                         self._timeUntilStartOfWindow = 0;
                         self.resume();
@@ -163,7 +163,7 @@ require.def(
                 function detectIfUnpaused(event) {
                     if (event.state !== MediaPlayer.STATE.PAUSED) {
                         self.removeEventCallback(self, detectIfUnpaused);
-                        clearTimeout(autoPlayTimer);
+                        clearTimeout(autoResumeTimer);
                         var timePaused = new Date().getTime() - pauseStarted;
                         self._timeUntilStartOfWindow -= timePaused;
                     }

--- a/static/script/devices/mediaplayer/live/restartable.js
+++ b/static/script/devices/mediaplayer/live/restartable.js
@@ -94,6 +94,7 @@ require.def(
 
             stop: function() {
                 this._mediaPlayer.stop();
+                this._stopDeterminingTimeUntilStartOfWindow();
             },
 
             reset: function() {
@@ -129,13 +130,17 @@ require.def(
             },
 
             _determineTimeUntilStartOfWindow: function () {
-                var self = this;
-                this.addEventCallback(this, detectCurrentTime);
-                function detectCurrentTime(event) {
-                    if (event.state === MediaPlayer.STATE.PLAYING && event.currentTime) {
-                        self.removeEventCallback(self, detectCurrentTime);
-                        self._timeUntilStartOfWindow = event.currentTime * 1000;
-                    }
+                this.addEventCallback(this, this._detectCurrentTimeCallback);
+            },
+
+            _stopDeterminingTimeUntilStartOfWindow: function () {
+                this.removeEventCallback(this, this._detectCurrentTimeCallback);
+            },
+
+            _detectCurrentTimeCallback: function (event) {
+                if (event.state === MediaPlayer.STATE.PLAYING && event.currentTime) {
+                    this.removeEventCallback(this, this._detectCurrentTimeCallback);
+                    this._timeUntilStartOfWindow = event.currentTime * 1000;
                 }
             },
 

--- a/static/script/devices/mediaplayer/live/restartable.js
+++ b/static/script/devices/mediaplayer/live/restartable.js
@@ -78,6 +78,14 @@ require.def(
                 this._mediaPlayer.setSource(mediaType, sourceUrl, mimeType);
             },
 
+            pause: function () {
+                this._mediaPlayer.pause();
+            },
+
+            resume: function () {
+                this._mediaPlayer.resume();
+            },
+
             stop: function() {
                 this._mediaPlayer.stop();
             },

--- a/static/script/devices/mediaplayer/live/restartable.js
+++ b/static/script/devices/mediaplayer/live/restartable.js
@@ -180,16 +180,12 @@ require.def(
             },
 
             _determineBufferingCallback: function (event) {
-                if (event.state === MediaPlayer.STATE.BUFFERING) {
-                    if (this._bufferingStarted === null) {
-                        this._bufferingStarted = new Date().getTime();
-                    }
-                } else {
-                    if (this._bufferingStarted !== null) {
-                        var timeBuffering = new Date().getTime() - this._bufferingStarted;
-                        this._timeUntilStartOfWindow = Math.max(0, this._timeUntilStartOfWindow - timeBuffering);
-                        this._bufferingStarted = null;
-                    }
+                if (event.state === MediaPlayer.STATE.BUFFERING && this._bufferingStarted === null) {
+                    this._bufferingStarted = new Date().getTime();
+                } else if (event.state !== MediaPlayer.STATE.BUFFERING && this._bufferingStarted !== null) {
+                    var timeBuffering = new Date().getTime() - this._bufferingStarted;
+                    this._timeUntilStartOfWindow = Math.max(0, this._timeUntilStartOfWindow - timeBuffering);
+                    this._bufferingStarted = null;
                 }
             }
         });

--- a/static/script/devices/mediaplayer/live/restartable.js
+++ b/static/script/devices/mediaplayer/live/restartable.js
@@ -69,8 +69,8 @@ require.def(
             },
 
             beginPlaybackFrom: function(offset) {
-                this._timeUntilStartOfWindow = offset * 1000;
                 this._mediaPlayer.beginPlaybackFrom(offset);
+                this._determineTimeUntilStartOfWindow();
             },
 
             setSource: function(mediaType, sourceUrl, mimeType) {

--- a/static/script/devices/mediaplayer/live/restartable.js
+++ b/static/script/devices/mediaplayer/live/restartable.js
@@ -132,7 +132,7 @@ require.def(
                 var self = this;
                 this.addEventCallback(this, detectCurrentTime);
                 function detectCurrentTime(event) {
-                    if ( event.state === MediaPlayer.STATE.PLAYING && event.currentTime ) {
+                    if (event.state === MediaPlayer.STATE.PLAYING && event.currentTime) {
                         self.removeEventCallback(self, detectCurrentTime);
                         self._timeUntilStartOfWindow = event.currentTime * 1000;
                     }
@@ -140,11 +140,9 @@ require.def(
             },
 
             _autoPlayAtStartOfRange: function () {
-
-                if ( this._timeUntilStartOfWindow !== null ) {
-                    var self = this;
-
-                    var start = new Date().getTime();
+                var self = this;
+                if (this._timeUntilStartOfWindow !== null) {
+                    var pauseStarted = new Date().getTime();
                     var autoPlayTimer = setTimeout(function () {
                         self.removeEventCallback(self, detectIfUnpaused);
                         self._timeUntilStartOfWindow = 0;
@@ -158,7 +156,8 @@ require.def(
                     if (event.state !== MediaPlayer.STATE.PAUSED) {
                         self.removeEventCallback(self, detectIfUnpaused);
                         clearTimeout(autoPlayTimer);
-                        self._timeUntilStartOfWindow -= (new Date().getTime() - start);
+                        var timePaused = new Date().getTime() - pauseStarted;
+                        self._timeUntilStartOfWindow -= timePaused;
                     }
                 }
             }

--- a/static/script/devices/mediaplayer/live/restartable.js
+++ b/static/script/devices/mediaplayer/live/restartable.js
@@ -147,6 +147,7 @@ require.def(
                     var start = new Date().getTime();
                     var autoPlayTimer = setTimeout(function () {
                         self.removeEventCallback(self, detectIfUnpaused);
+                        self._timeUntilStartOfWindow = 0;
                         self.resume();
                     }, self._timeUntilStartOfWindow);
 

--- a/static/script/devices/mediaplayer/live/restartable.js
+++ b/static/script/devices/mediaplayer/live/restartable.js
@@ -54,7 +54,7 @@ require.def(
         var RestartableLivePlayer = Class.extend({
             init: function() {
                 this._mediaPlayer = RuntimeContext.getDevice().getMediaPlayer();
-                this._timeUntilStartOfWindow = null;
+                this._millisecondsUntilStartOfWindow = null;
             },
 
             beginPlayback: function() {
@@ -69,7 +69,7 @@ require.def(
             },
 
             beginPlaybackFrom: function(offset) {
-                this._timeUntilStartOfWindow = offset * 1000;
+                this._millisecondsUntilStartOfWindow = offset * 1000;
                 this._mediaPlayer.beginPlaybackFrom(offset);
                 this._determineTimeSpentBuffering();
             },
@@ -142,20 +142,20 @@ require.def(
             _detectCurrentTimeCallback: function (event) {
                 if (event.state === MediaPlayer.STATE.PLAYING && event.currentTime) {
                     this.removeEventCallback(this, this._detectCurrentTimeCallback);
-                    this._timeUntilStartOfWindow = event.currentTime * 1000;
+                    this._millisecondsUntilStartOfWindow = event.currentTime * 1000;
                     this._determineTimeSpentBuffering();
                 }
             },
 
             _autoResumeAtStartOfRange: function () {
                 var self = this;
-                if (this._timeUntilStartOfWindow !== null) {
+                if (this._millisecondsUntilStartOfWindow !== null) {
                     var pauseStarted = new Date().getTime();
                     var autoResumeTimer = setTimeout(function () {
                         self.removeEventCallback(self, detectIfUnpaused);
-                        self._timeUntilStartOfWindow = 0;
+                        self._millisecondsUntilStartOfWindow = 0;
                         self.resume();
-                    }, self._timeUntilStartOfWindow);
+                    }, self._millisecondsUntilStartOfWindow);
 
                     this.addEventCallback(this, detectIfUnpaused);
                 }
@@ -165,7 +165,7 @@ require.def(
                         self.removeEventCallback(self, detectIfUnpaused);
                         clearTimeout(autoResumeTimer);
                         var timePaused = new Date().getTime() - pauseStarted;
-                        self._timeUntilStartOfWindow -= timePaused;
+                        self._millisecondsUntilStartOfWindow -= timePaused;
                     }
                 }
             },
@@ -184,7 +184,7 @@ require.def(
                     this._bufferingStarted = new Date().getTime();
                 } else if (event.state !== MediaPlayer.STATE.BUFFERING && this._bufferingStarted !== null) {
                     var timeBuffering = new Date().getTime() - this._bufferingStarted;
-                    this._timeUntilStartOfWindow = Math.max(0, this._timeUntilStartOfWindow - timeBuffering);
+                    this._millisecondsUntilStartOfWindow = Math.max(0, this._millisecondsUntilStartOfWindow - timeBuffering);
                     this._bufferingStarted = null;
                 }
             }

--- a/static/script/devices/mediaplayer/live/restartable.js
+++ b/static/script/devices/mediaplayer/live/restartable.js
@@ -155,7 +155,7 @@ require.def(
                 }
 
                 function detectIfUnpaused(event) {
-                    if (event.state !== MediaPlayer.STATE.PAUSE) {
+                    if (event.state !== MediaPlayer.STATE.PAUSED) {
                         self.removeEventCallback(self, detectIfUnpaused);
                         clearTimeout(autoPlayTimer);
                         self._timeUntilStartOfWindow -= (new Date().getTime() - start);

--- a/static/script/devices/mediaplayer/live/restartable.js
+++ b/static/script/devices/mediaplayer/live/restartable.js
@@ -69,8 +69,8 @@ require.def(
             },
 
             beginPlaybackFrom: function(offset) {
+                this._timeUntilStartOfWindow = offset * 1000;
                 this._mediaPlayer.beginPlaybackFrom(offset);
-                this._determineTimeUntilStartOfWindow();
             },
 
             setSource: function(mediaType, sourceUrl, mimeType) {

--- a/static/script/devices/mediaplayer/live/seekable.js
+++ b/static/script/devices/mediaplayer/live/seekable.js
@@ -140,7 +140,7 @@ require.def(
 
                 this.addEventCallback(this, detectIfUnpaused);
                 function detectIfUnpaused(event) {
-                    if (event.state !== MediaPlayer.STATE.PAUSE) {
+                    if (event.state !== MediaPlayer.STATE.PAUSED) {
                         self.removeEventCallback(self, detectIfUnpaused);
                         clearTimeout(autoPlayTimer);
                     }

--- a/static/script/devices/mediaplayer/live/seekable.js
+++ b/static/script/devices/mediaplayer/live/seekable.js
@@ -130,7 +130,7 @@ require.def(
             },
 
             _autoPlayAtStartOfRange: function () {
-                var timeUntilStartOfWindow = this._mediaPlayer.getCurrentTime() - this._mediaPlayer.getSeekableRange().start,
+                var timeUntilStartOfWindow = Math.max(0, this._mediaPlayer.getCurrentTime() - this._mediaPlayer.getSeekableRange().start),
                     self = this;
 
                 var autoPlayTimer = setTimeout(function () {

--- a/static/script/devices/mediaplayer/live/seekable.js
+++ b/static/script/devices/mediaplayer/live/seekable.js
@@ -130,8 +130,8 @@ require.def(
             },
 
             _autoPlayAtStartOfRange: function () {
-                var timeUntilStartOfWindow = Math.max(0, this._mediaPlayer.getCurrentTime() - this._mediaPlayer.getSeekableRange().start),
-                    self = this;
+                var self = this;
+                var timeUntilStartOfWindow = Math.max(0, this._mediaPlayer.getCurrentTime() - this._mediaPlayer.getSeekableRange().start);
 
                 var autoPlayTimer = setTimeout(function () {
                     self.removeEventCallback(self, detectIfUnpaused);

--- a/static/script/devices/mediaplayer/live/seekable.js
+++ b/static/script/devices/mediaplayer/live/seekable.js
@@ -81,24 +81,6 @@ require.def(
                 this._autoPlayAtStartOfRange();
             },
 
-            _autoPlayAtStartOfRange: function () {
-                var timeUntilStartOfWindow = this._mediaPlayer.getCurrentTime() - this._mediaPlayer.getSeekableRange().start,
-                    self = this;
-
-                var autoPlayTimer = setTimeout(function () {
-                    self.removeEventCallback(this, detectIfUnpaused);
-                    self.resume();
-                }, timeUntilStartOfWindow * 1000);
-
-                this.addEventCallback(this, detectIfUnpaused);
-                function detectIfUnpaused(event) {
-                    if (event.state !== MediaPlayer.STATE.PAUSE) {
-                        self.removeEventCallback(this, detectIfUnpaused);
-                        clearTimeout(autoPlayTimer);
-                    }
-                }
-            },
-
             resume: function () {
                 this._mediaPlayer.resume();
             },
@@ -145,6 +127,24 @@ require.def(
 
             getPlayerElement: function () {
                 return this._mediaPlayer.getPlayerElement();
+            },
+
+            _autoPlayAtStartOfRange: function () {
+                var timeUntilStartOfWindow = this._mediaPlayer.getCurrentTime() - this._mediaPlayer.getSeekableRange().start,
+                    self = this;
+
+                var autoPlayTimer = setTimeout(function () {
+                    self.removeEventCallback(self, detectIfUnpaused);
+                    self.resume();
+                }, timeUntilStartOfWindow * 1000);
+
+                this.addEventCallback(this, detectIfUnpaused);
+                function detectIfUnpaused(event) {
+                    if (event.state !== MediaPlayer.STATE.PAUSE) {
+                        self.removeEventCallback(self, detectIfUnpaused);
+                        clearTimeout(autoPlayTimer);
+                    }
+                }
             }
         });
 

--- a/static/script/devices/mediaplayer/live/seekable.js
+++ b/static/script/devices/mediaplayer/live/seekable.js
@@ -78,7 +78,7 @@ require.def(
 
             pause: function () {
                 this._mediaPlayer.pause();
-                this._autoPlayAtStartOfRange();
+                this._autoResumeAtStartOfRange();
             },
 
             resume: function () {
@@ -129,11 +129,11 @@ require.def(
                 return this._mediaPlayer.getPlayerElement();
             },
 
-            _autoPlayAtStartOfRange: function () {
+            _autoResumeAtStartOfRange: function () {
                 var self = this;
                 var timeUntilStartOfWindow = Math.max(0, this._mediaPlayer.getCurrentTime() - this._mediaPlayer.getSeekableRange().start);
 
-                var autoPlayTimer = setTimeout(function () {
+                var autoResumeTimer = setTimeout(function () {
                     self.removeEventCallback(self, detectIfUnpaused);
                     self.resume();
                 }, timeUntilStartOfWindow * 1000);
@@ -142,7 +142,7 @@ require.def(
                 function detectIfUnpaused(event) {
                     if (event.state !== MediaPlayer.STATE.PAUSED) {
                         self.removeEventCallback(self, detectIfUnpaused);
-                        clearTimeout(autoPlayTimer);
+                        clearTimeout(autoResumeTimer);
                     }
                 }
             }

--- a/static/script/devices/mediaplayer/live/seekable.js
+++ b/static/script/devices/mediaplayer/live/seekable.js
@@ -45,11 +45,11 @@ require.def(
          * @extends antie.Class
          */
         var SeekableLivePlayer = Class.extend({
-            init: function() {
+            init: function () {
                 this._mediaPlayer = RuntimeContext.getDevice().getMediaPlayer();
             },
 
-            setSource: function(mediaType, sourceUrl, mimeType) {
+            setSource: function (mediaType, sourceUrl, mimeType) {
                 if (mediaType === MediaPlayer.TYPE.AUDIO) {
                     mediaType = MediaPlayer.TYPE.LIVE_AUDIO;
                 } else {
@@ -59,7 +59,7 @@ require.def(
                 this._mediaPlayer.setSource(mediaType, sourceUrl, mimeType);
             },
 
-            beginPlayback: function() {
+            beginPlayback: function () {
                 var config = RuntimeContext.getDevice().getConfig();
                 if (config && config.streaming && config.streaming.overrides && config.streaming.overrides.forceBeginPlaybackToEndOfWindow) {
                     this._mediaPlayer.beginPlaybackFrom(Infinity);
@@ -68,63 +68,82 @@ require.def(
                 }
             },
 
-            beginPlaybackFrom: function(offset) {
+            beginPlaybackFrom: function (offset) {
                 this._mediaPlayer.beginPlaybackFrom(offset);
             },
 
-            playFrom: function(offset) {
+            playFrom: function (offset) {
                 this._mediaPlayer.playFrom(offset);
             },
 
-            pause: function() {
+            pause: function () {
                 this._mediaPlayer.pause();
+                this._autoPlayAtStartOfRange();
             },
 
-            resume: function() {
+            _autoPlayAtStartOfRange: function () {
+                var timeUntilStartOfWindow = this._mediaPlayer.getCurrentTime() - this._mediaPlayer.getSeekableRange().start,
+                    self = this;
+
+                var autoPlayTimer = setTimeout(function () {
+                    self.removeEventCallback(this, detectIfUnpaused);
+                    self.resume();
+                }, timeUntilStartOfWindow * 1000);
+
+                this.addEventCallback(this, detectIfUnpaused);
+                function detectIfUnpaused(event) {
+                    if (event.state !== MediaPlayer.STATE.PAUSE) {
+                        self.removeEventCallback(this, detectIfUnpaused);
+                        clearTimeout(autoPlayTimer);
+                    }
+                }
+            },
+
+            resume: function () {
                 this._mediaPlayer.resume();
             },
 
-            stop: function() {
+            stop: function () {
                 this._mediaPlayer.stop();
             },
 
-            reset: function() {
+            reset: function () {
                 this._mediaPlayer.reset();
             },
 
-            getState: function() {
+            getState: function () {
                 return this._mediaPlayer.getState();
             },
 
-            getSource: function() {
+            getSource: function () {
                 return this._mediaPlayer.getSource();
             },
 
-            getCurrentTime: function() {
+            getCurrentTime: function () {
                 return this._mediaPlayer.getCurrentTime();
             },
 
-            getSeekableRange: function() {
+            getSeekableRange: function () {
                 return this._mediaPlayer.getSeekableRange();
             },
 
-            getMimeType: function() {
+            getMimeType: function () {
                 return this._mediaPlayer.getMimeType();
             },
 
-            addEventCallback: function(thisArg, callback) {
+            addEventCallback: function (thisArg, callback) {
                 this._mediaPlayer.addEventCallback(thisArg, callback);
             },
 
-            removeEventCallback: function(thisArg, callback) {
+            removeEventCallback: function (thisArg, callback) {
                 this._mediaPlayer.removeEventCallback(thisArg, callback);
             },
 
-            removeAllEventCallbacks: function() {
+            removeAllEventCallbacks: function () {
                 this._mediaPlayer.removeAllEventCallbacks();
             },
 
-            getPlayerElement: function() {
+            getPlayerElement: function () {
                 return this._mediaPlayer.getPlayerElement();
             }
         });
@@ -132,7 +151,7 @@ require.def(
         var instance;
 
         Device.prototype.getLivePlayer = function () {
-            if(!instance) {
+            if (!instance) {
                 instance = new SeekableLivePlayer();
             }
             return instance;


### PR DESCRIPTION
1) Added pause and resume to restartable API

2) Added auto-resume functionality so that video automatically resumes when paused and the start of the window reaches the pause point. There are different implementations for seekable and restartable. For seekable when paused we can calculate the time until the start of the window from the current time and the seekable range. For restartable we calculate the time from the start of the window on initial play, then update this be deducting time spent buffering and paused.