### PR TITLE
Remove the v from tag name in bump

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -92,7 +92,7 @@ module.exports = function (grunt) {
             commitMessage: 'Release v%VERSION%',
             commitFiles: ['package.json', 'bower.json'],
             createTag: true,
-            tagName: 'v%VERSION%',
+            tagName: '%VERSION%',
             tagMessage: 'Version %VERSION%',
             push: true,
             pushTo: 'origin',


### PR DESCRIPTION
So that the tag name doesn't go vX.Y.Z but X.Y.Z like it should