### PR TITLE
IPTV-673 Moved isBroadcastSupported Device modifier out of base class.

### DIFF
--- a/static/script-tests/tests/devices/broadcastsource/basetvsourcetest.js
+++ b/static/script-tests/tests/devices/broadcastsource/basetvsourcetest.js
@@ -140,16 +140,6 @@
         });
     };
 
-    this.baseTvSource.prototype.testBaseBroadcastSourceDoesNotModifyIsBroadcastSourceSupportedOnDevice = function(queue) {
-        expectAsserts(1);
-        var config = getGenericBaseBroadcastConfig();
-        queuedApplicationInit(queue, 'lib/mockapplication', [], function(application) {
-            var device = application.getDevice();
-            assertFalse(device.isBroadcastSourceSupported());
-        }, config);
-    };
-
-
     this.baseTvSource.prototype.testBaseBroadcastSourceGetCurrentChannelThrowsExceptionWhenNotOverridden = function(queue) {
         expectAsserts(1);
         queuedApplicationInit(queue, 'lib/mockapplication', ["antie/devices/broadcastsource/basetvsource"], function(application, BaseTvSource) {

--- a/static/script-tests/tests/devices/broadcastsource/basetvsourcetest.js
+++ b/static/script-tests/tests/devices/broadcastsource/basetvsourcetest.js
@@ -140,12 +140,12 @@
         });
     };
 
-    this.baseTvSource.prototype.testBaseBroadcastSourceIsBroadcastSourceSupportedReturnsTrue = function(queue) {
+    this.baseTvSource.prototype.testBaseBroadcastSourceDoesNotModifyIsBroadcastSourceSupportedOnDevice = function(queue) {
         expectAsserts(1);
         var config = getGenericBaseBroadcastConfig();
         queuedApplicationInit(queue, 'lib/mockapplication', [], function(application) {
             var device = application.getDevice();
-            assertTrue(device.isBroadcastSourceSupported());
+            assertFalse(device.isBroadcastSourceSupported());
         }, config);
     };
 

--- a/static/script/devices/broadcastsource/basetvsource.js
+++ b/static/script/devices/broadcastsource/basetvsource.js
@@ -119,14 +119,10 @@ require.def('antie/devices/broadcastsource/basetvsource',
          */
         BaseTvSource.STATE = {
             UNKNOWN: "UNKNOWN", // tuner state not known
-	    UNAVAILABLE:    "UNAVAILABLE",     // No tuner available
-            CONNECTING:    "CONNECTING",   // tuner attempting to connect
-            PRESENTING:    "PRESENTING",   // tuner is presenting a channel
-	    STOPPED: "STOPPED" // tuner is stopped
-        };
-
-        Device.prototype.isBroadcastSourceSupported = function() {
-            return true;
+            UNAVAILABLE: "UNAVAILABLE", // No tuner available
+            CONNECTING: "CONNECTING", // tuner attempting to connect
+            PRESENTING: "PRESENTING", // tuner is presenting a channel
+            STOPPED: "STOPPED" // tuner is stopped
         };
 
         return BaseTvSource;

--- a/static/script/devices/broadcastsource/samsungtvsource.js
+++ b/static/script/devices/broadcastsource/samsungtvsource.js
@@ -276,6 +276,10 @@ require.def('antie/devices/broadcastsource/samsungtvsource',
 
         });
 
+        Device.prototype.isBroadcastSourceSupported = function() {
+            return true;
+        };
+
         /**
          * Create a new widget giving control over broadcast television. Check whether
          * the broadcast television API is available first with isBroadcastSourceSupported().

--- a/static/script/devices/broadcastsource/tizentvsource.js
+++ b/static/script/devices/broadcastsource/tizentvsource.js
@@ -327,6 +327,10 @@ require.def('antie/devices/broadcastsource/tizentvsource', [
 
         });
 
+        Device.prototype.isBroadcastSourceSupported = function() {
+            return true;
+        };
+
         /**
          * Create a new widget giving control over broadcast television. Check
          * whether the broadcast television API is available first with


### PR DESCRIPTION
Previously requiring in basetvsource for access to the STATE property would overwrite the Device prototype often unintentionally.
Moved prototype manipulation to "sub classes" of basetvsource (samsungtvsource and tizentvsource).
Updated the tests to reflect the fact that a config that uses the basetvsource as a modifier will not affect the isBroadcastSupported method.
Fixed inconsistent indentation in basetvsource.js