### PR TITLE
Added a quick note and link between index and config pages

### DIFF
--- a/getting-started/tutorial/createanindex.md
+++ b/getting-started/tutorial/createanindex.md
@@ -27,7 +27,7 @@ that are necessary for a functioning application:
 The index should be placed in the root of your application and acts as an entry point.
 It needs to be delivered as a page formatted appropriately for the device, and should accomplish the following:
 
-* Load a configuration file for the type of device using the application
+* Load a **[configuration file]({{site.baseurl}}/overview/device-configuration.html)** for the type of device using the application
 * Define an 'Application ID' string and substitute this into the configuration wherever the token `%application%` appears
 * Provide the substituted configuration as a nested object within a javascript global variable 'antie'
 * Load any device specific api code / plugin objects

--- a/overview/device-configuration.md
+++ b/overview/device-configuration.md
@@ -7,6 +7,9 @@ title: Device Configuration
 <p class="lead">Device configurations are managed by a set of JSON files.
 Each file represents a device or family of similar devices.</p>
 
+The configuration files are loaded at runtime in the **[app index]({{site.baseurl}}/getting-started/tutorial/createanindex.html)** and exposed
+as a Javascript object to the framework.
+
 Configuration is split into two sets. The framework configuration files
 which specify a set of default values required by the framework itself, and an
 application file which can override these defaults and include additional


### PR DESCRIPTION
I thought this would be useful for new people coming to TAL.

I found it a little confusing at first while reading the configuration overview exactly how and where the files are used, so I thought a link between that page and the index creation page would be useful.

Hope it's useful, happy to change if required.