### PR TITLE
Fixed fullscreen issue, while application is not 1080p

### DIFF
--- a/static/script-tests/tests/devices/broadcastsource/tizentvsourcetest.js
+++ b/static/script-tests/tests/devices/broadcastsource/tizentvsourcetest.js
@@ -143,11 +143,7 @@
             var device = application.getDevice();
             var broadcastSource = device.createBroadcastSource();
 
-            self.sandbox.stub(application, 'getLayout', function() {
-                return {
-                    requiredScreenSize: { height: 1080, width: 1920 }
-                };
-            });
+            self.sandbox.stub(window, "screen", { height: 1080, width: 1920 });
 
             broadcastSource.showCurrentChannel();
 

--- a/static/script/devices/broadcastsource/tizentvsource.js
+++ b/static/script/devices/broadcastsource/tizentvsource.js
@@ -252,8 +252,7 @@ require.def(
             },
 
             _setBroadcastToFullScreen: function () {
-                var currentLayout = RuntimeContext.getCurrentApplication().getLayout().requiredScreenSize;
-                this.setPosition(0, 0, currentLayout.width, currentLayout.height);
+                this.setPosition(0, 0, window.screen.width, window.screen.height);
             },
 
             _tuneToChannelByName: function (params) {


### PR DESCRIPTION
We have noticed that broadcast isn't shown on fullscreen when application is in resolution lower than 1080p. This change should fix the issue.