### PR TITLE
Improving node

### DIFF
--- a/node/antie.js
+++ b/node/antie.js
@@ -1,0 +1,15 @@
+var fs = require('fs')
+
+module.exports = {
+    getPageStrategyElement: function(pageStrategy, element) {
+        var pageStrategyPath = __dirname + '/../config/pagestrategy/' + pageStrategy + '/' + element;
+        if (!fs.existsSync(pageStrategyPath)) {
+            return {
+                noSuchStrategy: "file does not exist: " + pageStrategyPath
+            }
+        }
+        return {
+            data: fs.readFileSync(pageStrategyPath).toString()
+        }
+    }
+}

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
         "url": "https://github.com/fmtvp/tal.git"
     },
     "description": "Library for building applications for Connected TV devices",
-    "main": "./node/antieframework.js",
+    "main": "./node/antie.js",
     "directories": {
         "node": "./node",
         "config": "./config",

--- a/package.json
+++ b/package.json
@@ -1,30 +1,36 @@
 {
-  "name": "tal",
-  "license": "Apache-2.0",
-  "version": "3.1.0",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/fmtvp/tal.git"
-  },
-  "description": "Library for building applications for Connected TV devices",
-  "devDependencies": {
-    "eslint-plugin-jasmine": "^1.6.0",
-    "eslint-plugin-requirejs": "^0.6.0",
-    "exec-sync": "latest",
-    "grunt": "^0.4.5",
-    "grunt-bump": "^0.6.0",
-    "grunt-cli": "~0.1.6",
-    "grunt-complexity": "^0.2.0",
-    "grunt-contrib-jasmine": "~0.5.2",
-    "grunt-contrib-jshint": "~0.10.0",
-    "grunt-contrib-watch": "~0.6.1",
-    "grunt-shell": "^1.1.1",
-    "grunt-text-replace": "^0.4.0",
-    "gruntify-eslint": "^1.3.0",
-    "jsdoc-toolkit": "latest"
-  },
-  "dependencies": {},
-  "scripts": {
-    "test": "grunt full --verbose"
-  }
+    "name": "tal",
+    "license": "Apache-2.0",
+    "version": "3.1.3",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/fmtvp/tal.git"
+    },
+    "description": "Library for building applications for Connected TV devices",
+    "main": "./node/antieframework.js",
+    "directories": {
+        "node": "./node",
+        "config": "./config",
+        "static": "./static/script"
+    },
+    "devDependencies": {
+        "eslint-plugin-jasmine": "^1.6.0",
+        "eslint-plugin-requirejs": "^0.6.0",
+        "exec-sync": "latest",
+        "grunt": "^0.4.5",
+        "grunt-bump": "^0.6.0",
+        "grunt-cli": "~0.1.6",
+        "grunt-complexity": "^0.2.0",
+        "grunt-contrib-jasmine": "~0.5.2",
+        "grunt-contrib-jshint": "~0.10.0",
+        "grunt-contrib-watch": "~0.6.1",
+        "grunt-shell": "^1.1.1",
+        "grunt-text-replace": "^0.4.0",
+        "gruntify-eslint": "^1.3.0",
+        "jsdoc-toolkit": "latest"
+    },
+    "dependencies": {},
+    "scripts": {
+        "test": "grunt full --verbose"
+    }
 }


### PR DESCRIPTION
When you do an npm install you can now run the code
```
var antie = require('tal')
antie.getPageStrategyElement('hbbtv', 'body')
```

the antieframework.js is too complicated to do this. Also updated the package.json which needs updating and publishing once this has been merged