### PR TITLE
require.def migration

### DIFF
--- a/static/script-tests/jasmine/jstestdriver-adapter.js
+++ b/static/script-tests/jasmine/jstestdriver-adapter.js
@@ -5,7 +5,7 @@ var unloadRequire;
 	var requireModules = { };
 
 	var originalDef = require.def;
-	var originalDefine = require.define;
+	var originalDefine = define;
 	var originalLoad = require.load;
 
 	require.def = function() {
@@ -14,7 +14,7 @@ var unloadRequire;
 		originalDef.apply(require, arguments);
 	};
 
-	require.define = function() {
+	define = function() {
 		var name = arguments[0];
 		requireModules[name] = arguments;
 		originalDefine.apply(require, arguments);

--- a/static/script/application.js
+++ b/static/script/application.js
@@ -24,7 +24,7 @@
  * Please contact us for an alternative licence
  */
 
-require.def('antie/application',
+define('antie/application',
     [
         'antie/class',
         'antie/runtimecontext',

--- a/static/script/audiosource.js
+++ b/static/script/audiosource.js
@@ -24,7 +24,7 @@
  * Please contact us for an alternative licence
  */
 
-require.def(
+define(
     'antie/audiosource',
     ['antie/mediasource'],
     function(MediaSource) {

--- a/static/script/callbackmanager.js
+++ b/static/script/callbackmanager.js
@@ -24,7 +24,7 @@
  * Please contact us for an alternative licence
  */
 
-require.def('antie/callbackmanager',
+define('antie/callbackmanager',
     [
         'antie/class'
     ],

--- a/static/script/class.js
+++ b/static/script/class.js
@@ -9,7 +9,7 @@
  * @author John Resig <eresig@gmail.com>
  */
 
-require.def('antie/class', function() {
+define('antie/class', function() {
     "use strict";
     var initializing = false, fnTest = /var xyz/.test(function () { var xyz; }) ? /\b_super\b/ : /.*/;
 

--- a/static/script/datasource.js
+++ b/static/script/datasource.js
@@ -24,7 +24,7 @@
  * Please contact us for an alternative licence
  */
 
-require.def(
+define(
     'antie/datasource',
     ['antie/class'],
     function(Class) {

--- a/static/script/devices/anim/css3.js
+++ b/static/script/devices/anim/css3.js
@@ -24,7 +24,7 @@
  * Please contact us for an alternative licence
  */
 
-require.def(
+define(
     'antie/devices/anim/css3',
     [
         'antie/devices/browserdevice',

--- a/static/script/devices/anim/css3/easinglookup.js
+++ b/static/script/devices/anim/css3/easinglookup.js
@@ -24,7 +24,7 @@
  * Please contact us for an alternative licence
  */
 
-require.def(
+define(
     'antie/devices/anim/css3/easinglookup',
     [
         'antie/class'

--- a/static/script/devices/anim/css3/existingtransitiondefinition.js
+++ b/static/script/devices/anim/css3/existingtransitiondefinition.js
@@ -26,7 +26,7 @@
 
 
 
-require.def(
+define(
     'antie/devices/anim/css3/existingtransitiondefinition',
     [
         'antie/devices/anim/css3/transitiondefinition'

--- a/static/script/devices/anim/css3/optionstransitiondefinition.js
+++ b/static/script/devices/anim/css3/optionstransitiondefinition.js
@@ -25,7 +25,7 @@
  */
 
 
-require.def(
+define(
     'antie/devices/anim/css3/optionstransitiondefinition',
     [
         'antie/devices/anim/css3/transitiondefinition'

--- a/static/script/devices/anim/css3/skipanimtransitiondefinition.js
+++ b/static/script/devices/anim/css3/skipanimtransitiondefinition.js
@@ -24,7 +24,7 @@
  * Please contact us for an alternative licence
  */
 
-require.def(
+define(
     'antie/devices/anim/css3/skipanimtransitiondefinition',
     [
         'antie/devices/anim/css3/transitiondefinition'

--- a/static/script/devices/anim/css3/stringhelpers.js
+++ b/static/script/devices/anim/css3/stringhelpers.js
@@ -24,7 +24,7 @@
  * Please contact us for an alternative licence
  */
 
-require.def(
+define(
     'antie/devices/anim/css3/stringhelpers',
     [
         'antie/class'

--- a/static/script/devices/anim/css3/transition.js
+++ b/static/script/devices/anim/css3/transition.js
@@ -24,7 +24,7 @@
  * Please contact us for an alternative licence
  */
 
-require.def(
+define(
     'antie/devices/anim/css3/transition',
     [
         'antie/class',

--- a/static/script/devices/anim/css3/transitiondefinition.js
+++ b/static/script/devices/anim/css3/transitiondefinition.js
@@ -24,7 +24,7 @@
  * Please contact us for an alternative licence
  */
 
-require.def(
+define(
     'antie/devices/anim/css3/transitiondefinition',
     [
         'antie/class',

--- a/static/script/devices/anim/css3/transitionelement.js
+++ b/static/script/devices/anim/css3/transitionelement.js
@@ -24,7 +24,7 @@
  * Please contact us for an alternative licence
  */
 
-require.def(
+define(
     'antie/devices/anim/css3/transitionelement',
     [
         'antie/class',

--- a/static/script/devices/anim/noanim.js
+++ b/static/script/devices/anim/noanim.js
@@ -24,7 +24,7 @@
  * Please contact us for an alternative licence
  */
 
-require.def(
+define(
     'antie/devices/anim/noanim',
     [
         'antie/devices/browserdevice',

--- a/static/script/devices/anim/shared/transitionendpoints.js
+++ b/static/script/devices/anim/shared/transitionendpoints.js
@@ -24,7 +24,7 @@
  * Please contact us for an alternative licence
  */
 
-require.def(
+define(
     'antie/devices/anim/shared/transitionendpoints',
     [
         'antie/class'

--- a/static/script/devices/anim/styletopleft.js
+++ b/static/script/devices/anim/styletopleft.js
@@ -24,7 +24,7 @@
  * Please contact us for an alternative licence
  */
 
-require.def(
+define(
     'antie/devices/anim/styletopleft',
     [
         'antie/devices/browserdevice',

--- a/static/script/devices/anim/tween.js
+++ b/static/script/devices/anim/tween.js
@@ -24,7 +24,7 @@
  * Please contact us for an alternative licence
  */
 
-require.def(
+define(
     'antie/devices/anim/tween',
     [
         'antie/devices/browserdevice',

--- a/static/script/devices/broadcastsource/basetvsource.js
+++ b/static/script/devices/broadcastsource/basetvsource.js
@@ -24,7 +24,7 @@
  * Please contact us for an alternative licence
  */
 
-require.def(
+define(
     'antie/devices/broadcastsource/basetvsource',
     [
         'antie/class'

--- a/static/script/devices/broadcastsource/hbbtvsource.js
+++ b/static/script/devices/broadcastsource/hbbtvsource.js
@@ -24,7 +24,7 @@
  * Please contact us for an alternative licence
  */
 
-require.def(
+define(
     'antie/devices/broadcastsource/hbbtvsource',
     [
         'antie/devices/browserdevice',

--- a/static/script/devices/broadcastsource/samsungtvsource.js
+++ b/static/script/devices/broadcastsource/samsungtvsource.js
@@ -26,7 +26,7 @@
  * Please contact us for an alternative licence
  */
 
-require.def(
+define(
     'antie/devices/broadcastsource/samsungtvsource',
     [
         'antie/devices/browserdevice',

--- a/static/script/devices/broadcastsource/stubbedsource.js
+++ b/static/script/devices/broadcastsource/stubbedsource.js
@@ -3,7 +3,7 @@
  * @license See https://github.com/fmtvp/tal/blob/master/LICENSE for full licence
  */
 
-require.def('antie/devices/broadcastsource/stubbedsource',
+define('antie/devices/broadcastsource/stubbedsource',
     [
         'antie/devices/browserdevice',
         'antie/devices/broadcastsource/basetvsource'

--- a/static/script/devices/broadcastsource/tizentvsource.js
+++ b/static/script/devices/broadcastsource/tizentvsource.js
@@ -26,7 +26,7 @@
  * Please contact us for an alternative licence
  */
 
-require.def(
+define(
     'antie/devices/broadcastsource/tizentvsource',
     [
         'antie/devices/browserdevice',

--- a/static/script/devices/browserdevice.js
+++ b/static/script/devices/browserdevice.js
@@ -25,7 +25,7 @@
  * Please contact us for an alternative licence
  */
 
-require.def(
+define(
     'antie/devices/browserdevice',
     [
         'antie/devices/device',

--- a/static/script/devices/data/json2.js
+++ b/static/script/devices/data/json2.js
@@ -2,7 +2,7 @@
  * @fileOverview Requirejs modifier to use J Crockford's JSON2 implementation.
  */
 
-require.def(
+define(
 	"antie/devices/data/json2",
 	['antie/devices/browserdevice'],
 	function(Device) {

--- a/static/script/devices/data/nativejson.js
+++ b/static/script/devices/data/nativejson.js
@@ -24,7 +24,7 @@
  * Please contact us for an alternative licence
  */
 
-require.def(
+define(
     'antie/devices/data/nativejson',
     ['antie/devices/browserdevice'],
     function(Device) {

--- a/static/script/devices/device.js
+++ b/static/script/devices/device.js
@@ -50,7 +50,7 @@
  * @namespace
  */
 
-require.def(
+define(
     'antie/devices/device',
     [
         'antie/class',

--- a/static/script/devices/exit/broadcast/netcast.js
+++ b/static/script/devices/exit/broadcast/netcast.js
@@ -24,7 +24,7 @@
  * Please contact us for an alternative licence
  */
 
-require.def(
+define(
     'antie/devices/exit/broadcast/netcast',
     ['antie/devices/browserdevice'],
     function(Device) {

--- a/static/script/devices/exit/broadcast/samsung_maple.js
+++ b/static/script/devices/exit/broadcast/samsung_maple.js
@@ -26,7 +26,7 @@
  * Please contact us for an alternative licence
  */
 
-require.def(
+define(
     'antie/devices/exit/broadcast/samsung_maple',
     ['antie/devices/browserdevice'],
     function(Device) {

--- a/static/script/devices/exit/closewindow.js
+++ b/static/script/devices/exit/closewindow.js
@@ -24,7 +24,7 @@
  * Please contact us for an alternative licence
  */
 
-require.def(
+define(
     'antie/devices/exit/closewindow',
     ['antie/devices/browserdevice'],
     function(Device) {

--- a/static/script/devices/exit/destroyapplication.js
+++ b/static/script/devices/exit/destroyapplication.js
@@ -28,7 +28,7 @@
  * Please contact us for an alternative licence
  */
 
-require.def(
+define(
     'antie/devices/exit/destroyapplication',
     ['antie/devices/browserdevice'],
     function(Device) {

--- a/static/script/devices/exit/history.js
+++ b/static/script/devices/exit/history.js
@@ -24,7 +24,7 @@
  * Please contact us for an alternative licence
  */
 
-require.def(
+define(
     'antie/devices/exit/history',
     ['antie/devices/browserdevice'],
     function(Device) {

--- a/static/script/devices/exit/netcast.js
+++ b/static/script/devices/exit/netcast.js
@@ -24,7 +24,7 @@
  * Please contact us for an alternative licence
  */
 
-require.def(
+define(
     'antie/devices/exit/netcast',
     ['antie/devices/browserdevice'],
     function(Device) {

--- a/static/script/devices/exit/openclosewindow.js
+++ b/static/script/devices/exit/openclosewindow.js
@@ -26,7 +26,7 @@
  * Please contact us for an alternative licence
  */
 
-require.def(
+define(
     'antie/devices/exit/openclosewindow',
     ['antie/devices/browserdevice'],
     function(Device) {

--- a/static/script/devices/exit/sagemcom.js
+++ b/static/script/devices/exit/sagemcom.js
@@ -24,7 +24,7 @@
  * Please contact us for an alternative licence
  */
 
-require.def(
+define(
     'antie/devices/exit/sagemcom',
     ['antie/devices/browserdevice'],
     function(Device) {

--- a/static/script/devices/exit/samsung_maple.js
+++ b/static/script/devices/exit/samsung_maple.js
@@ -25,7 +25,7 @@
 * Please contact us for an alternative licence
 */
 
-require.def('antie/devices/exit/samsung_maple', ['antie/devices/browserdevice'], function(Device) {
+define('antie/devices/exit/samsung_maple', ['antie/devices/browserdevice'], function(Device) {
     'use strict';
 
     /**

--- a/static/script/devices/exit/samsung_tizen.js
+++ b/static/script/devices/exit/samsung_tizen.js
@@ -26,7 +26,7 @@
  * Please contact us for an alternative licence
  */
 
-require.def(
+define(
     'antie/devices/exit/samsung_tizen',
     ['antie/devices/browserdevice'],
     function(Device) {

--- a/static/script/devices/exit/tivo.js
+++ b/static/script/devices/exit/tivo.js
@@ -24,7 +24,7 @@
  * All rights reserved
  * Please contact us for an alternative licence
  */
-require.def(
+define(
     'antie/devices/exit/tivo',
     ['antie/devices/browserdevice'],
     function(Device) {

--- a/static/script/devices/googletv.js
+++ b/static/script/devices/googletv.js
@@ -24,7 +24,7 @@
  * Please contact us for an alternative licence
  */
 
-require.def('antie/devices/googletv',
+define('antie/devices/googletv',
 	[
 		'antie/devices/browserdevice',
 		'antie/runtimecontext'

--- a/static/script/devices/logging/alert.js
+++ b/static/script/devices/logging/alert.js
@@ -24,7 +24,7 @@
  * Please contact us for an alternative licence
  */
 
-require.def(
+define(
     'antie/devices/logging/alert',
     [
         'module',

--- a/static/script/devices/logging/consumelog.js
+++ b/static/script/devices/logging/consumelog.js
@@ -25,7 +25,7 @@
  */
 
 // equivalent of logging to >dev/null
-require.def(
+define(
     'antie/devices/logging/consumelog',
     [
         'module',

--- a/static/script/devices/logging/default.js
+++ b/static/script/devices/logging/default.js
@@ -26,7 +26,7 @@
 
 
 //logs to the javascript console
-require.def(
+define(
     'antie/devices/logging/default',
     [
         'module',

--- a/static/script/devices/logging/jstestdriver.js
+++ b/static/script/devices/logging/jstestdriver.js
@@ -27,7 +27,7 @@
  */
 
 //logs to the jstestdriver console
-require.def(
+define(
     'antie/devices/logging/jstestdriver',
     [
         'module',

--- a/static/script/devices/logging/onscreen.js
+++ b/static/script/devices/logging/onscreen.js
@@ -25,7 +25,7 @@
  */
 
 //logs to the screen
-require.def(
+define(
     'antie/devices/logging/onscreen',
     [
         'module',

--- a/static/script/devices/logging/saving.js
+++ b/static/script/devices/logging/saving.js
@@ -25,7 +25,7 @@
  */
 
 // Saves the logs for access later
-require.def(
+define(
     'antie/devices/logging/saving',
     [
         'module',

--- a/static/script/devices/logging/xhr.js
+++ b/static/script/devices/logging/xhr.js
@@ -25,7 +25,7 @@
  */
 
 //Logs to via an XML HTTP Request ( XHR )
-require.def(
+define(
     'antie/devices/logging/xhr',
     [
         'module',

--- a/static/script/devices/media/cehtml.js
+++ b/static/script/devices/media/cehtml.js
@@ -24,7 +24,7 @@
  * Please contact us for an alternative licence
  */
 
-require.def(
+define(
     'antie/devices/media/cehtml',
     [
         'antie/devices/device',

--- a/static/script/devices/media/cehtmlmediatypefix.js
+++ b/static/script/devices/media/cehtmlmediatypefix.js
@@ -26,7 +26,7 @@
  * Please contact us for an alternative licence
  */
 
-require.def(
+define(
     'antie/devices/media/cehtmlmediatypefix',
     [
         'antie/devices/media/cehtml'

--- a/static/script/devices/media/html5.js
+++ b/static/script/devices/media/html5.js
@@ -26,7 +26,7 @@
  * Please contact us for an alternative licence
  */
 
-require.def(
+define(
     'antie/devices/media/html5',
     [
         'antie/devices/device',

--- a/static/script/devices/media/html5memoryleakfix.js
+++ b/static/script/devices/media/html5memoryleakfix.js
@@ -25,7 +25,7 @@
  * Please contact us for an alternative licence
  */
 
-require.def(
+define(
     'antie/devices/media/html5memoryleakfix',
     [
         'antie/devices/media/html5'

--- a/static/script/devices/media/html5untyped.js
+++ b/static/script/devices/media/html5untyped.js
@@ -25,7 +25,7 @@
  * Please contact us for an alternative licence
  */
 
-require.def(
+define(
     'antie/devices/media/html5untyped',
     [
         'antie/devices/media/html5'

--- a/static/script/devices/media/html5waitingfix.js
+++ b/static/script/devices/media/html5waitingfix.js
@@ -25,7 +25,7 @@
  * Please contact us for an alternative licence
  */
 
-require.def(
+define(
     'antie/devices/media/html5waitingfix',
     [
         'antie/devices/media/html5',

--- a/static/script/devices/media/mediainterface.js
+++ b/static/script/devices/media/mediainterface.js
@@ -24,7 +24,7 @@
  * Please contact us for an alternative licence
  */
 
-require.def(
+define(
     'antie/devices/media/mediainterface',
     [
         'antie/class'

--- a/static/script/devices/media/native.js
+++ b/static/script/devices/media/native.js
@@ -24,7 +24,7 @@
  * Please contact us for an alternative licence
  */
 
-require.def(
+define(
     'antie/devices/media/native',
     [
         'antie/devices/device',

--- a/static/script/devices/media/samsung_maple.js
+++ b/static/script/devices/media/samsung_maple.js
@@ -24,7 +24,7 @@
  * Please contact us for an alternative licence
  */
 
-require.def(
+define(
     'antie/devices/media/samsung_maple',
     [
         'antie/devices/device',

--- a/static/script/devices/media/samsung_maple_unload.js
+++ b/static/script/devices/media/samsung_maple_unload.js
@@ -1,4 +1,4 @@
-require.def(
+define(
     'antie/devices/media/samsung_maple_unload',
     [
         'antie/devices/media/samsung_maple'

--- a/static/script/devices/media/seekstate.js
+++ b/static/script/devices/media/seekstate.js
@@ -25,7 +25,7 @@
  * Please contact us for an alternative licence
  */
 
-require.def(
+define(
     'antie/devices/media/seekstate',
     [
         'antie/class',

--- a/static/script/devices/mediaplayer/cehtml.js
+++ b/static/script/devices/mediaplayer/cehtml.js
@@ -24,7 +24,7 @@
  * Please contact us for an alternative licence
  */
 
-require.def(
+define(
     'antie/devices/mediaplayer/cehtml',
     [
         'antie/devices/device',

--- a/static/script/devices/mediaplayer/cehtmlseekfinishedemitevent.js
+++ b/static/script/devices/mediaplayer/cehtmlseekfinishedemitevent.js
@@ -1,4 +1,4 @@
-require.def(
+define(
     'antie/devices/mediaplayer/cehtmlseekfinishedemitevent',
     [
         'antie/devices/mediaplayer/seekfinishedemitevent',

--- a/static/script/devices/mediaplayer/html5.js
+++ b/static/script/devices/mediaplayer/html5.js
@@ -24,7 +24,7 @@
  * Please contact us for an alternative licence
  */
 
-require.def(
+define(
     'antie/devices/mediaplayer/html5',
     [
         'antie/runtimecontext',

--- a/static/script/devices/mediaplayer/html5memoryleakunfix.js
+++ b/static/script/devices/mediaplayer/html5memoryleakunfix.js
@@ -25,7 +25,7 @@
  * Please contact us for an alternative licence
  */
 
-require.def(
+define(
     'antie/devices/mediaplayer/html5memoryleakunfix',
     [
         'antie/devices/mediaplayer/html5'

--- a/static/script/devices/mediaplayer/html5seekfinishedemitevent.js
+++ b/static/script/devices/mediaplayer/html5seekfinishedemitevent.js
@@ -1,4 +1,4 @@
-require.def(
+define(
     'antie/devices/mediaplayer/html5seekfinishedemitevent',
     [
         'antie/devices/mediaplayer/seekfinishedemitevent',

--- a/static/script/devices/mediaplayer/html5untyped.js
+++ b/static/script/devices/mediaplayer/html5untyped.js
@@ -25,7 +25,7 @@
  * Please contact us for an alternative licence
  */
 
-require.def(
+define(
     'antie/devices/mediaplayer/html5untyped',
     [
         'antie/runtimecontext',

--- a/static/script/devices/mediaplayer/live/none.js
+++ b/static/script/devices/mediaplayer/live/none.js
@@ -25,7 +25,7 @@
  * Please contact us for an alternative licence
  */
 
-require.def(
+define(
     'antie/devices/mediaplayer/live/none',
     [
         'antie/devices/device',

--- a/static/script/devices/mediaplayer/live/playable.js
+++ b/static/script/devices/mediaplayer/live/playable.js
@@ -25,7 +25,7 @@
  * Please contact us for an alternative licence
  */
 
-require.def(
+define(
     'antie/devices/mediaplayer/live/playable',
     [
         'antie/class',

--- a/static/script/devices/mediaplayer/live/restartable.js
+++ b/static/script/devices/mediaplayer/live/restartable.js
@@ -25,7 +25,7 @@
  * Please contact us for an alternative licence
  */
 
-require.def(
+define(
     'antie/devices/mediaplayer/live/restartable',
     [
         'antie/class',

--- a/static/script/devices/mediaplayer/live/seekable.js
+++ b/static/script/devices/mediaplayer/live/seekable.js
@@ -25,7 +25,7 @@
  * Please contact us for an alternative licence
  */
 
-require.def(
+define(
     'antie/devices/mediaplayer/live/seekable',
     [
         'antie/class',

--- a/static/script/devices/mediaplayer/mediaplayer.js
+++ b/static/script/devices/mediaplayer/mediaplayer.js
@@ -25,7 +25,7 @@
  * Please contact us for an alternative licence
  */
 
-require.def(
+define(
     'antie/devices/mediaplayer/mediaplayer',
     [
         'antie/class',

--- a/static/script/devices/mediaplayer/samsung_maple.js
+++ b/static/script/devices/mediaplayer/samsung_maple.js
@@ -24,7 +24,7 @@
  * Please contact us for an alternative licence
  */
 
-require.def(
+define(
     'antie/devices/mediaplayer/samsung_maple',
     [
         'antie/devices/device',

--- a/static/script/devices/mediaplayer/seekfinishedemitevent.js
+++ b/static/script/devices/mediaplayer/seekfinishedemitevent.js
@@ -27,7 +27,7 @@
  * All rights reserved
  * Please contact us for an alternative licence
  */
-require.def(
+define(
     'antie/devices/mediaplayer/seekfinishedemitevent',
     [
         'antie/devices/mediaplayer/mediaplayer',

--- a/static/script/devices/net/default.js
+++ b/static/script/devices/net/default.js
@@ -24,7 +24,7 @@
  * Please contact us for an alternative licence
  */
 
-require.def(
+define(
     'antie/devices/net/default',
     ['antie/devices/browserdevice'],
     function (Device) {

--- a/static/script/devices/net/xhrthiswindow.js
+++ b/static/script/devices/net/xhrthiswindow.js
@@ -24,7 +24,7 @@
  * Please contact us for an alternative licence
  */
 
-require.def(
+define(
     'antie/devices/net/xhrthiswindow',
     [
         'antie/devices/browserdevice'

--- a/static/script/devices/parentalguidance/appdefaultpghandler.js
+++ b/static/script/devices/parentalguidance/appdefaultpghandler.js
@@ -21,7 +21,7 @@
  * All rights reserved
  * Please contact us for an alternative licence
  */
-require.def(
+define(
     'antie/devices/parentalguidance/appdefaultpghandler',
     [
         'antie/devices/browserdevice',

--- a/static/script/devices/parentalguidance/basepghandler.js
+++ b/static/script/devices/parentalguidance/basepghandler.js
@@ -21,7 +21,7 @@
  * All rights reserved
  * Please contact us for an alternative licence
  */
-require.def('antie/devices/parentalguidance/basepghandler',
+define('antie/devices/parentalguidance/basepghandler',
     [
         'antie/class'
     ],

--- a/static/script/devices/parentalguidance/pgchallengeresponse.js
+++ b/static/script/devices/parentalguidance/pgchallengeresponse.js
@@ -1,4 +1,4 @@
-require.def(
+define(
     'antie/devices/parentalguidance/pgchallengeresponse',
     [],
     function () {

--- a/static/script/devices/parentalguidance/youviewpghandler.js
+++ b/static/script/devices/parentalguidance/youviewpghandler.js
@@ -21,7 +21,7 @@
  * All rights reserved
  * Please contact us for an alternative licence
  */
-require.def(
+define(
     'antie/devices/parentalguidance/youviewpghandler',
     [
         'antie/devices/browserdevice',

--- a/static/script/devices/ps3base.js
+++ b/static/script/devices/ps3base.js
@@ -24,7 +24,7 @@
  * Please contact us for an alternative licence
  */
 
-require.def(
+define(
     'antie/devices/ps3base',
     [
         'antie/devices/browserdevice',

--- a/static/script/devices/sanitiser.js
+++ b/static/script/devices/sanitiser.js
@@ -23,7 +23,7 @@
  * All rights reserved
  * Please contact us for an alternative licence
  */
-require.def('antie/devices/sanitiser', [], function () {
+define('antie/devices/sanitiser', [], function () {
 
     'use strict';
 

--- a/static/script/devices/sanitisers/whitelisted.js
+++ b/static/script/devices/sanitisers/whitelisted.js
@@ -23,7 +23,7 @@
  * All rights reserved
  * Please contact us for an alternative licence
  */
-require.def(
+define(
     'antie/devices/sanitisers/whitelisted',
     [
         'antie/devices/sanitiser',

--- a/static/script/devices/storage/cookie.js
+++ b/static/script/devices/storage/cookie.js
@@ -24,7 +24,7 @@
  * Please contact us for an alternative licence
  */
 
-require.def(
+define(
     'antie/devices/storage/cookie',
     [
         'antie/devices/browserdevice',

--- a/static/script/devices/storage/session.js
+++ b/static/script/devices/storage/session.js
@@ -24,7 +24,7 @@
  * Please contact us for an alternative licence
  */
 
-require.def(
+define(
     'antie/devices/storage/session',
     ['antie/storageprovider'],
     function(StorageProvider) {

--- a/static/script/devices/storage/xboxpls.js
+++ b/static/script/devices/storage/xboxpls.js
@@ -3,7 +3,7 @@
  * @license See https://github.com/fmtvp/tal/blob/master/LICENSE for full licence
  */
 
-require.def(
+define(
     'antie/devices/storage/xboxpls',
     [
         'antie/devices/browserdevice',

--- a/static/script/devices/wiiu.js
+++ b/static/script/devices/wiiu.js
@@ -27,7 +27,7 @@
  */
 
 
-require.def(
+define(
     'antie/devices/wiiu',
     [
         'antie/devices/browserdevice',

--- a/static/script/events/afteralignevent.js
+++ b/static/script/events/afteralignevent.js
@@ -23,7 +23,7 @@
  * All rights reserved
  * Please contact us for an alternative licence
  */
-require.def(
+define(
     'antie/events/afteralignevent',
     ['antie/events/event'],
     function (Event) {

--- a/static/script/events/beforealignevent.js
+++ b/static/script/events/beforealignevent.js
@@ -23,7 +23,7 @@
  * All rights reserved
  * Please contact us for an alternative licence
  */
-require.def('antie/events/beforealignevent',
+define('antie/events/beforealignevent',
     ['antie/events/event'],
     function (Event) {
         'use strict';

--- a/static/script/events/beforeselecteditemchangeevent.js
+++ b/static/script/events/beforeselecteditemchangeevent.js
@@ -24,7 +24,7 @@
  * Please contact us for an alternative licence
  */
 
-require.def(
+define(
     'antie/events/beforeselecteditemchangeevent',
     ['antie/events/event'],
     function(Event) {

--- a/static/script/events/blurevent.js
+++ b/static/script/events/blurevent.js
@@ -24,7 +24,7 @@
  * Please contact us for an alternative licence
  */
 
-require.def(
+define(
     'antie/events/blurevent',
     ['antie/events/event'],
     function(Event) {

--- a/static/script/events/componentevent.js
+++ b/static/script/events/componentevent.js
@@ -25,7 +25,7 @@
  */
 
 
-require.def(
+define(
     'antie/events/componentevent',
     ['antie/events/event'],
     function(Event) {

--- a/static/script/events/databoundevent.js
+++ b/static/script/events/databoundevent.js
@@ -24,7 +24,7 @@
  * Please contact us for an alternative licence
  */
 
-require.def(
+define(
     'antie/events/databoundevent',
     ['antie/events/event'],
     function(Event) {

--- a/static/script/events/event.js
+++ b/static/script/events/event.js
@@ -34,7 +34,7 @@
  * @namespace
  */
 
-require.def(
+define(
     'antie/events/event',
     [
         'antie/class',

--- a/static/script/events/focusdelayevent.js
+++ b/static/script/events/focusdelayevent.js
@@ -24,7 +24,7 @@
  * Please contact us for an alternative licence
  */
 
-require.def(
+define(
     'antie/events/focusdelayevent',
     ['antie/events/event'],
     function(Event) {

--- a/static/script/events/focusevent.js
+++ b/static/script/events/focusevent.js
@@ -24,7 +24,7 @@
  * Please contact us for an alternative licence
  */
 
-require.def(
+define(
     'antie/events/focusevent',
     ['antie/events/event'],
     function(Event) {

--- a/static/script/events/keyevent.js
+++ b/static/script/events/keyevent.js
@@ -24,7 +24,7 @@
  * Please contact us for an alternative licence
  */
 
-require.def(
+define(
     'antie/events/keyevent',
     ['antie/events/event'],
     function(Event) {

--- a/static/script/events/mediaerrorevent.js
+++ b/static/script/events/mediaerrorevent.js
@@ -24,7 +24,7 @@
  * Please contact us for an alternative licence
  */
 
-require.def(
+define(
     'antie/events/mediaerrorevent',
     ['antie/events/mediaevent'],
     function(MediaEvent) {

--- a/static/script/events/mediaevent.js
+++ b/static/script/events/mediaevent.js
@@ -24,7 +24,7 @@
  * Please contact us for an alternative licence
  */
 
-require.def(
+define(
     'antie/events/mediaevent',
     ['antie/events/event'],
     function(Event) {

--- a/static/script/events/mediasourceerrorevent.js
+++ b/static/script/events/mediasourceerrorevent.js
@@ -24,7 +24,7 @@
  * Please contact us for an alternative licence
  */
 
-require.def(
+define(
     'antie/events/mediasourceerrorevent',
     ['antie/events/mediaerrorevent'],
     function(MediaErrorEvent) {

--- a/static/script/events/networkstatuschangeevent.js
+++ b/static/script/events/networkstatuschangeevent.js
@@ -24,7 +24,7 @@
  * Please contact us for an alternative licence
  */
 
-require.def(
+define(
     'antie/events/networkstatuschangeevent',
     ['antie/events/event'],
     function(Event) {

--- a/static/script/events/pagechangeevent.js
+++ b/static/script/events/pagechangeevent.js
@@ -24,7 +24,7 @@
  * Please contact us for an alternative licence
  */
 
-require.def(
+define(
     'antie/events/pagechangeevent',
     ['antie/events/event'],
     function(Event) {

--- a/static/script/events/selecteditemchangeevent.js
+++ b/static/script/events/selecteditemchangeevent.js
@@ -24,7 +24,7 @@
  * Please contact us for an alternative licence
  */
 
-require.def(
+define(
     'antie/events/selecteditemchangeevent',
     ['antie/events/event'],
     function(Event) {

--- a/static/script/events/selectevent.js
+++ b/static/script/events/selectevent.js
@@ -24,7 +24,7 @@
  * Please contact us for an alternative licence
  */
 
-require.def(
+define(
     'antie/events/selectevent',
     ['antie/events/event'],
     function(Event) {

--- a/static/script/events/sliderchangeevent.js
+++ b/static/script/events/sliderchangeevent.js
@@ -24,7 +24,7 @@
  * Please contact us for an alternative licence
  */
 
-require.def(
+define(
     'antie/events/sliderchangeevent',
     ['antie/events/event'],
     function(Event) {

--- a/static/script/events/textchangeevent.js
+++ b/static/script/events/textchangeevent.js
@@ -24,7 +24,7 @@
  * Please contact us for an alternative licence
  */
 
-require.def(
+define(
     'antie/events/textchangeevent',
     ['antie/events/event'],
     function(Event) {

--- a/static/script/events/textpagechangeevent.js
+++ b/static/script/events/textpagechangeevent.js
@@ -24,7 +24,7 @@
  * Please contact us for an alternative licence
  */
 
-require.def(
+define(
     'antie/events/textpagechangeevent',
     ['antie/events/event'],
     function(Event) {

--- a/static/script/events/tunerpresentingevent.js
+++ b/static/script/events/tunerpresentingevent.js
@@ -24,7 +24,7 @@
  * Please contact us for an alternative licence
  */
 
-require.def(
+define(
     'antie/events/tunerpresentingevent',
     ['antie/events/event'],
     function (Event) {

--- a/static/script/events/tunerstoppedevent.js
+++ b/static/script/events/tunerstoppedevent.js
@@ -24,7 +24,7 @@
  * Please contact us for an alternative licence
  */
 
-require.def(
+define(
     'antie/events/tunerstoppedevent',
     ['antie/events/event'],
     function (Event) {

--- a/static/script/events/tunerunavailableevent.js
+++ b/static/script/events/tunerunavailableevent.js
@@ -24,7 +24,7 @@
  * Please contact us for an alternative licence
  */
 
-require.def(
+define(
     'antie/events/tunerunavailableevent',
     ['antie/events/event'],
     function (Event) {

--- a/static/script/formatter.js
+++ b/static/script/formatter.js
@@ -24,7 +24,7 @@
  * Please contact us for an alternative licence
  */
 
-require.def(
+define(
     'antie/formatter',
     [
         'antie/class'

--- a/static/script/historian.js
+++ b/static/script/historian.js
@@ -24,7 +24,7 @@
  * Please contact us for an alternative licence
  */
 
-require.def(
+define(
     'antie/historian',
     [
         'antie/class'

--- a/static/script/iterator.js
+++ b/static/script/iterator.js
@@ -24,7 +24,7 @@
  * Please contact us for an alternative licence
  */
 
-require.def(
+define(
     'antie/iterator',
     ['antie/class'],
     function(Class) {

--- a/static/script/lib/array.indexof.js
+++ b/static/script/lib/array.indexof.js
@@ -1,4 +1,4 @@
-require.def('antie/lib/array.indexof', function() {
+define('antie/lib/array.indexof', function() {
 
   // From: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/indexOf
   // License: CC-BY-SA 2.5. http://creativecommons.org/licenses/by-sa/2.5/

--- a/static/script/lib/date.format.js
+++ b/static/script/lib/date.format.js
@@ -1,4 +1,4 @@
-require.def('antie/lib/date.format', function() {
+define('antie/lib/date.format', function() {
 
 // Simulates PHP's date function
 // From: http://jacwright.com/projects/javascript/date_format

--- a/static/script/lib/date.parse.js
+++ b/static/script/lib/date.parse.js
@@ -1,4 +1,4 @@
-require.def('antie/lib/date.parse', function() {
+define('antie/lib/date.parse', function() {
 
 /**
  * Date.parse with progressive enhancement for ISO-8601

--- a/static/script/lib/intervalformat.js
+++ b/static/script/lib/intervalformat.js
@@ -1,4 +1,4 @@
-require.def('antie/lib/intervalformat', function() {
+define('antie/lib/intervalformat', function() {
 	var _unitOrder = ['years', 'months', 'days', 'hours', 'minutes', 'seconds'];
 	var _divisors = {
 		'years': 60 * 60 * 24 * 365,

--- a/static/script/lib/math.seedrandom.js
+++ b/static/script/lib/math.seedrandom.js
@@ -1,4 +1,4 @@
-require.def('antie/lib/math.seedrandom', function() {
+define('antie/lib/math.seedrandom', function() {
 
 // seedrandom.js
 // Author: David Bau 12/25/2010

--- a/static/script/lib/sha1.js
+++ b/static/script/lib/sha1.js
@@ -1,4 +1,4 @@
-require.def('antie/lib/sha1', function() {
+define('antie/lib/sha1', function() {
 /*
  * A JavaScript implementation of the Secure Hash Algorithm, SHA-1, as defined
  * in FIPS 180-1

--- a/static/script/lib/shifty.js
+++ b/static/script/lib/shifty.js
@@ -1,4 +1,4 @@
-require.def('antie/lib/shifty', function() {
+define('antie/lib/shifty', function() {
 
 	/*global setTimeout:true, clearTimeout:true */
 

--- a/static/script/mediasource.js
+++ b/static/script/mediasource.js
@@ -24,7 +24,7 @@
  * Please contact us for an alternative licence
  */
 
-require.def(
+define(
     'antie/mediasource',
     [
         'antie/class',

--- a/static/script/packages/core.js
+++ b/static/script/packages/core.js
@@ -1,4 +1,4 @@
-require.def('antie/packages/core',[
+define('antie/packages/core',[
     'antie/application',
     'antie/mediasource',
     'antie/videosource',

--- a/static/script/runtimecontext.js
+++ b/static/script/runtimecontext.js
@@ -24,7 +24,7 @@
  * Please contact us for an alternative licence
  */
 
-require.def(
+define(
     'antie/runtimecontext',
     [
         'antie/class'

--- a/static/script/storageprovider.js
+++ b/static/script/storageprovider.js
@@ -24,7 +24,7 @@
  * Please contact us for an alternative licence
  */
 
-require.def(
+define(
     'antie/storageprovider',
     ['antie/class'],
     function(Class) {

--- a/static/script/urlbuilder.js
+++ b/static/script/urlbuilder.js
@@ -24,7 +24,7 @@
  * Please contact us for an alternative licence
  */
 
-require.def(
+define(
     'antie/urlbuilder',
     ['antie/class'],
     function(Class) {

--- a/static/script/videosource.js
+++ b/static/script/videosource.js
@@ -24,7 +24,7 @@
  * Please contact us for an alternative licence
  */
 
-require.def(
+define(
     'antie/videosource',
     ['antie/mediasource'],
     function(MediaSource) {

--- a/static/script/widgets/button.js
+++ b/static/script/widgets/button.js
@@ -24,7 +24,7 @@
  * Please contact us for an alternative licence
  */
 
-require.def(
+define(
     'antie/widgets/button',
     [
         'antie/widgets/container',

--- a/static/script/widgets/carousel.js
+++ b/static/script/widgets/carousel.js
@@ -22,7 +22,7 @@
  * Please contact us for an alternative licence
  */
 
-require.def(
+define(
     'antie/widgets/carousel',
     [
         'antie/widgets/carousel/carouselcore',

--- a/static/script/widgets/carousel/aligners/aligner.js
+++ b/static/script/widgets/carousel/aligners/aligner.js
@@ -21,7 +21,7 @@
  * All rights reserved
  * Please contact us for an alternative licence
  */
-require.def(
+define(
     'antie/widgets/carousel/aligners/aligner',
     [
         'antie/class',

--- a/static/script/widgets/carousel/aligners/alignmentqueue.js
+++ b/static/script/widgets/carousel/aligners/alignmentqueue.js
@@ -21,7 +21,7 @@
  * All rights reserved
  * Please contact us for an alternative licence
  */
-require.def(
+define(
     'antie/widgets/carousel/aligners/alignmentqueue',
     [
         'antie/class'

--- a/static/script/widgets/carousel/binder.js
+++ b/static/script/widgets/carousel/binder.js
@@ -21,7 +21,7 @@
  * All rights reserved
  * Please contact us for an alternative licence
  */
-require.def(
+define(
     'antie/widgets/carousel/binder',
     [
         'antie/class',

--- a/static/script/widgets/carousel/binders/batchbinder.js
+++ b/static/script/widgets/carousel/binders/batchbinder.js
@@ -21,7 +21,7 @@
  * All rights reserved
  * Please contact us for an alternative licence
  */
-require.def(
+define(
     'antie/widgets/carousel/binders/batchbinder',
     [
         'antie/widgets/carousel/binder'

--- a/static/script/widgets/carousel/carouselcore.js
+++ b/static/script/widgets/carousel/carouselcore.js
@@ -24,7 +24,7 @@
  * Please contact us for an alternative licence
  */
 
-require.def(
+define(
     'antie/widgets/carousel/carouselcore',
     [
         'antie/widgets/container',

--- a/static/script/widgets/carousel/keyhandlers/activatefirsthandler.js
+++ b/static/script/widgets/carousel/keyhandlers/activatefirsthandler.js
@@ -21,7 +21,7 @@
  * All rights reserved
  * Please contact us for an alternative licence
  */
-require.def(
+define(
     'antie/widgets/carousel/keyhandlers/activatefirsthandler',
     [
         'antie/widgets/carousel/keyhandlers/keyhandler'

--- a/static/script/widgets/carousel/keyhandlers/alignfirsthandler.js
+++ b/static/script/widgets/carousel/keyhandlers/alignfirsthandler.js
@@ -21,7 +21,7 @@
  * All rights reserved
  * Please contact us for an alternative licence
  */
-require.def(
+define(
     'antie/widgets/carousel/keyhandlers/alignfirsthandler',
     [
         'antie/widgets/carousel/keyhandlers/keyhandler'

--- a/static/script/widgets/carousel/keyhandlers/keyhandler.js
+++ b/static/script/widgets/carousel/keyhandlers/keyhandler.js
@@ -21,7 +21,7 @@
  * All rights reserved
  * Please contact us for an alternative licence
  */
-require.def(
+define(
     'antie/widgets/carousel/keyhandlers/keyhandler',
     [
         'antie/class'

--- a/static/script/widgets/carousel/mask.js
+++ b/static/script/widgets/carousel/mask.js
@@ -21,7 +21,7 @@
  * All rights reserved
  * Please contact us for an alternative licence
  */
-require.def(
+define(
     'antie/widgets/carousel/mask',
     [
         'antie/widgets/container',

--- a/static/script/widgets/carousel/navigators/bookendednavigator.js
+++ b/static/script/widgets/carousel/navigators/bookendednavigator.js
@@ -22,7 +22,7 @@
  * Please contact us for an alternative licence
  */
 
-require.def(
+define(
     'antie/widgets/carousel/navigators/bookendednavigator',
     [
         'antie/widgets/carousel/navigators/navigator'

--- a/static/script/widgets/carousel/navigators/navigator.js
+++ b/static/script/widgets/carousel/navigators/navigator.js
@@ -21,7 +21,7 @@
  * All rights reserved
  * Please contact us for an alternative licence
  */
-require.def(
+define(
     'antie/widgets/carousel/navigators/navigator',
     [
         'antie/class',

--- a/static/script/widgets/carousel/navigators/wrappingnavigator.js
+++ b/static/script/widgets/carousel/navigators/wrappingnavigator.js
@@ -22,7 +22,7 @@
  * Please contact us for an alternative licence
  */
 
-require.def(
+define(
     'antie/widgets/carousel/navigators/wrappingnavigator',
     [
         'antie/widgets/carousel/navigators/navigator'

--- a/static/script/widgets/carousel/orientations/horizontal.js
+++ b/static/script/widgets/carousel/orientations/horizontal.js
@@ -21,7 +21,7 @@
  * All rights reserved
  * Please contact us for an alternative licence
  */
-require.def(
+define(
     'antie/widgets/carousel/orientations/horizontal',
     [
         'antie/class',

--- a/static/script/widgets/carousel/orientations/vertical.js
+++ b/static/script/widgets/carousel/orientations/vertical.js
@@ -21,7 +21,7 @@
  * All rights reserved
  * Please contact us for an alternative licence
  */
-require.def(
+define(
     'antie/widgets/carousel/orientations/vertical',
     [
         'antie/class',

--- a/static/script/widgets/carousel/spinner.js
+++ b/static/script/widgets/carousel/spinner.js
@@ -22,7 +22,7 @@
  * Please contact us for an alternative licence
  */
 
-require.def(
+define(
     'antie/widgets/carousel/spinner',
     [
         'antie/class'

--- a/static/script/widgets/carousel/strips/cullingstrip.js
+++ b/static/script/widgets/carousel/strips/cullingstrip.js
@@ -21,7 +21,7 @@
  * All rights reserved
  * Please contact us for an alternative licence
  */
-require.def(
+define(
     'antie/widgets/carousel/strips/cullingstrip',
     [
         'antie/widgets/carousel/strips/widgetstrip',

--- a/static/script/widgets/carousel/strips/hidingstrip.js
+++ b/static/script/widgets/carousel/strips/hidingstrip.js
@@ -21,7 +21,7 @@
  * All rights reserved
  * Please contact us for an alternative licence
  */
-require.def('antie/widgets/carousel/strips/hidingstrip',
+define('antie/widgets/carousel/strips/hidingstrip',
     [
         'antie/widgets/carousel/strips/cullingstrip',
         'antie/widgets/carousel/strips/utility/widgetcontext',

--- a/static/script/widgets/carousel/strips/utility/attachedstate.js
+++ b/static/script/widgets/carousel/strips/utility/attachedstate.js
@@ -21,7 +21,7 @@
  * All rights reserved
  * Please contact us for an alternative licence
  */
-require.def(
+define(
     'antie/widgets/carousel/strips/utility/attachedstate',
     [
         'antie/widgets/carousel/strips/utility/state'

--- a/static/script/widgets/carousel/strips/utility/hiddenstate.js
+++ b/static/script/widgets/carousel/strips/utility/hiddenstate.js
@@ -21,7 +21,7 @@
  * All rights reserved
  * Please contact us for an alternative licence
  */
-require.def(
+define(
     'antie/widgets/carousel/strips/utility/hiddenstate',
     [
         'antie/widgets/carousel/strips/utility/state'

--- a/static/script/widgets/carousel/strips/utility/initstate.js
+++ b/static/script/widgets/carousel/strips/utility/initstate.js
@@ -21,7 +21,7 @@
  * All rights reserved
  * Please contact us for an alternative licence
  */
-require.def(
+define(
     'antie/widgets/carousel/strips/utility/initstate',
     [
         'antie/widgets/carousel/strips/utility/state'

--- a/static/script/widgets/carousel/strips/utility/renderedstate.js
+++ b/static/script/widgets/carousel/strips/utility/renderedstate.js
@@ -21,7 +21,7 @@
  * All rights reserved
  * Please contact us for an alternative licence
  */
-require.def('antie/widgets/carousel/strips/utility/renderedstate',
+define('antie/widgets/carousel/strips/utility/renderedstate',
     [
         'antie/widgets/carousel/strips/utility/state'
     ],

--- a/static/script/widgets/carousel/strips/utility/state.js
+++ b/static/script/widgets/carousel/strips/utility/state.js
@@ -21,7 +21,7 @@
  * All rights reserved
  * Please contact us for an alternative licence
  */
-require.def(
+define(
     'antie/widgets/carousel/strips/utility/state',
     [
         'antie/class'

--- a/static/script/widgets/carousel/strips/utility/states.js
+++ b/static/script/widgets/carousel/strips/utility/states.js
@@ -21,7 +21,7 @@
  * All rights reserved
  * Please contact us for an alternative licence
  */
-require.def('antie/widgets/carousel/strips/utility/states',
+define('antie/widgets/carousel/strips/utility/states',
     [
         'antie/widgets/carousel/strips/utility/initstate',
         'antie/widgets/carousel/strips/utility/renderedstate',

--- a/static/script/widgets/carousel/strips/utility/visibilitystates.js
+++ b/static/script/widgets/carousel/strips/utility/visibilitystates.js
@@ -21,7 +21,7 @@
  * All rights reserved
  * Please contact us for an alternative licence
  */
-require.def('antie/widgets/carousel/strips/utility/visibilitystates',
+define('antie/widgets/carousel/strips/utility/visibilitystates',
     [
         'antie/widgets/carousel/strips/utility/initstate',
         'antie/widgets/carousel/strips/utility/hiddenstate',

--- a/static/script/widgets/carousel/strips/utility/visiblestate.js
+++ b/static/script/widgets/carousel/strips/utility/visiblestate.js
@@ -21,7 +21,7 @@
  * All rights reserved
  * Please contact us for an alternative licence
  */
-require.def(
+define(
     'antie/widgets/carousel/strips/utility/visiblestate',
     [
         'antie/widgets/carousel/strips/utility/state'

--- a/static/script/widgets/carousel/strips/utility/widgetcontext.js
+++ b/static/script/widgets/carousel/strips/utility/widgetcontext.js
@@ -21,7 +21,7 @@
  * All rights reserved
  * Please contact us for an alternative licence
  */
-require.def('antie/widgets/carousel/strips/utility/widgetcontext',
+define('antie/widgets/carousel/strips/utility/widgetcontext',
     [
         'antie/class'
     ],

--- a/static/script/widgets/carousel/strips/widgetstrip.js
+++ b/static/script/widgets/carousel/strips/widgetstrip.js
@@ -21,7 +21,7 @@
  * All rights reserved
  * Please contact us for an alternative licence
  */
-require.def(
+define(
     'antie/widgets/carousel/strips/widgetstrip',
     [
         'antie/widgets/container'

--- a/static/script/widgets/carousel/strips/wrappingstrip.js
+++ b/static/script/widgets/carousel/strips/wrappingstrip.js
@@ -21,7 +21,7 @@
  * All rights reserved
  * Please contact us for an alternative licence
  */
-require.def(
+define(
     'antie/widgets/carousel/strips/wrappingstrip',
     [
         'antie/widgets/carousel/strips/widgetstrip'

--- a/static/script/widgets/component.js
+++ b/static/script/widgets/component.js
@@ -24,7 +24,7 @@
  * Please contact us for an alternative licence
  */
 
-require.def('antie/widgets/component',
+define('antie/widgets/component',
     [
         'antie/widgets/container',
         'antie/runtimecontext'

--- a/static/script/widgets/componentcontainer.js
+++ b/static/script/widgets/componentcontainer.js
@@ -24,7 +24,7 @@
  * Please contact us for an alternative licence
  */
 
-require.def('antie/widgets/componentcontainer',
+define('antie/widgets/componentcontainer',
     [
         'antie/widgets/container',
         'antie/events/componentevent'

--- a/static/script/widgets/container.js
+++ b/static/script/widgets/container.js
@@ -24,7 +24,7 @@
  * Please contact us for an alternative licence
  */
 
-require.def(
+define(
     'antie/widgets/container',
     [
         'antie/widgets/widget',

--- a/static/script/widgets/grid.js
+++ b/static/script/widgets/grid.js
@@ -24,7 +24,7 @@
  * Please contact us for an alternative licence
  */
 
-require.def(
+define(
     'antie/widgets/grid',
     [
         'antie/widgets/container',

--- a/static/script/widgets/horizontalcarousel.js
+++ b/static/script/widgets/horizontalcarousel.js
@@ -24,7 +24,7 @@
  * Please contact us for an alternative licence
  */
 
-require.def('antie/widgets/horizontalcarousel',
+define('antie/widgets/horizontalcarousel',
     [
         'antie/widgets/horizontallist',
         'antie/widgets/list',

--- a/static/script/widgets/horizontallist.js
+++ b/static/script/widgets/horizontallist.js
@@ -24,7 +24,7 @@
  * Please contact us for an alternative licence
  */
 
-require.def(
+define(
     'antie/widgets/horizontallist',
     [
         'antie/widgets/list',

--- a/static/script/widgets/horizontalprogress.js
+++ b/static/script/widgets/horizontalprogress.js
@@ -24,7 +24,7 @@
  * Please contact us for an alternative licence
  */
 
-require.def('antie/widgets/horizontalprogress',
+define('antie/widgets/horizontalprogress',
     [
         'antie/widgets/container',
         'antie/widgets/label'

--- a/static/script/widgets/horizontalslider.js
+++ b/static/script/widgets/horizontalslider.js
@@ -24,7 +24,7 @@
  * Please contact us for an alternative licence
  */
 
-require.def(
+define(
     'antie/widgets/horizontalslider',
     [
         'antie/widgets/button',

--- a/static/script/widgets/image.js
+++ b/static/script/widgets/image.js
@@ -24,7 +24,7 @@
  * Please contact us for an alternative licence
  */
 
-require.def(
+define(
     'antie/widgets/image',
     ['antie/widgets/container'],
     function(Container) {

--- a/static/script/widgets/keyboard.js
+++ b/static/script/widgets/keyboard.js
@@ -24,7 +24,7 @@
  * Please contact us for an alternative licence
  */
 
-require.def(
+define(
     'antie/widgets/keyboard',
     [
         'antie/widgets/grid',

--- a/static/script/widgets/label.js
+++ b/static/script/widgets/label.js
@@ -24,7 +24,7 @@
  * Please contact us for an alternative licence
  */
 
-require.def(
+define(
     'antie/widgets/label',
     ['antie/widgets/widget'],
     function(Widget) {

--- a/static/script/widgets/list.js
+++ b/static/script/widgets/list.js
@@ -24,7 +24,7 @@
  * Please contact us for an alternative licence
  */
 
-require.def(
+define(
     'antie/widgets/list',
     [
         'antie/widgets/container',

--- a/static/script/widgets/listitem.js
+++ b/static/script/widgets/listitem.js
@@ -24,7 +24,7 @@
  * Please contact us for an alternative licence
  */
 
-require.def(
+define(
     'antie/widgets/listitem',
     ['antie/widgets/container'],
     function(Container) {

--- a/static/script/widgets/media.js
+++ b/static/script/widgets/media.js
@@ -24,7 +24,7 @@
  * Please contact us for an alternative licence
  */
 
-require.def(
+define(
     'antie/widgets/media',
     [
         'antie/widgets/widget',

--- a/static/script/widgets/scrubbar.js
+++ b/static/script/widgets/scrubbar.js
@@ -24,7 +24,7 @@
  * Please contact us for an alternative licence
  */
 
-require.def(
+define(
     'antie/widgets/scrubbar',
     ['antie/widgets/horizontalslider'],
     function(HorizontalSlider) {

--- a/static/script/widgets/state_view_container.js
+++ b/static/script/widgets/state_view_container.js
@@ -22,7 +22,7 @@
  * Please contact us for an alternative licence
  */
 
-require.def (
+define (
     'antie/widgets/state_view_container',
     [
         'antie/widgets/container',

--- a/static/script/widgets/textpager.js
+++ b/static/script/widgets/textpager.js
@@ -24,7 +24,7 @@
  * Please contact us for an alternative licence
  */
 
-require.def(
+define(
     'antie/widgets/textpager',
     [
         'antie/widgets/label',

--- a/static/script/widgets/verticallist.js
+++ b/static/script/widgets/verticallist.js
@@ -24,7 +24,7 @@
  * Please contact us for an alternative licence
  */
 
-require.def(
+define(
     'antie/widgets/verticallist',
     [
         'antie/widgets/list',

--- a/static/script/widgets/widget.js
+++ b/static/script/widgets/widget.js
@@ -30,7 +30,7 @@
  * @namespace
  */
 
-require.def(
+define(
     'antie/widgets/widget',
     [
         'antie/class',


### PR DESCRIPTION
This would resolve #345 and replaces all instances of `require.def` with `define`.

As raised in #345, `require.def`, which `tal` currently uses, doesn't work with newer versions of require - however, `define` does.

As you can see in our [require.js](https://github.com/fmtvp/tal/blob/master/static/script/lib/require.js#L255) file, `define` has the same functionality as `require.def`, so this PR replaces all instances of `require.def` with `define` for all files in [`/static/script/`](https://github.com/fmtvp/tal/tree/master/static/script) (except our [`require.js`](https://github.com/fmtvp/tal/blob/master/static/script/lib/require.js) file.