### PR TITLE
Change highlighter to be rouge

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,4 +1,4 @@
 baseurl:    /tal
-highlighter: pygments
+highlighter: rouge
 tal_release_version: "TAL_1.2.9b"
 


### PR DESCRIPTION
Github pages only support rouge and not pygments, and will fallback to using rouge even if you do
specify to use pygments anyway.

See:
https://github.com/blog/2100-github-pages-now-faster-and-simpler-with-jeky
ll-3-0

This allows support for backtick code blocks to be highlighted:
https://help.github.com/articles/creating-and-highlighting-code-blocks/