### PR TITLE
Fix for Issue 360 - CSS Classes for IMG Render Mode

### DIFF
--- a/static/script-tests/tests/widgets/image.js
+++ b/static/script-tests/tests/widgets/image.js
@@ -44,8 +44,9 @@
                 assert('Image should extend from Container', new Image() instanceof Container);
             });
     };
-    this.ImageTest.prototype.testRender = function(queue) {
-        expectAsserts(7);
+    
+    this.ImageTest.prototype.testRenderContainerMode = function(queue) {
+        expectAsserts(8);
 
         queuedApplicationInit(
             queue,
@@ -53,7 +54,8 @@
             ['antie/widgets/image'],
             function(application, Image) {
                 var size = {width: 107, height: 32};
-                var widget = new Image('id', 'about:blank', size);
+                var widget = new Image('id', 'about:blank', size, Image.RENDER_MODE_CONTAINER);
+                widget.addClass('testClass');
 
                 var device = application.getDevice();
                 var createImageSpy = this.sandbox.spy(device, 'createImage');
@@ -67,9 +69,65 @@
                 assertEquals(size.width + 'px', el.style.width);
                 assertEquals(size.height + 'px', el.style.height);
                 assertClassName('image', el);
+                assertClassName('testClass', el);
             }
         );
     };
+    
+    this.ImageTest.prototype.testRenderImgMode = function(queue) {
+        expectAsserts(6);
+
+        queuedApplicationInit(
+                queue,
+                'lib/mockapplication',
+                ['antie/widgets/image'],
+                function(application, Image) {
+                    var widget = new Image('id', 'about:blank', null, Image.RENDER_MODE_IMG);
+                    widget.addClass('testClass');
+
+                    var device = application.getDevice();
+                    var createImageSpy = this.sandbox.spy(device, 'createImage');
+                    var el = widget.render(device);
+
+                    assert(createImageSpy.called);
+                    assertEquals(typeof device.createImage(), typeof el);
+                    assertEquals('id_img', el.id);
+                    assertEquals('about:blank', el.src);
+                    assertClassName('image', el);
+                    assertClassName('testClass', el);
+                }
+        );
+    };
+
+     this.ImageTest.prototype.testRenderUnspecifiedMode = function(queue) {
+        expectAsserts(8);
+
+        queuedApplicationInit(
+                queue,
+                'lib/mockapplication',
+                ['antie/widgets/image'],
+                function(application, Image) {
+                    var size = {width: 107, height: 32};
+                    var widget = new Image('id', 'about:blank', size);
+                    widget.addClass('testClass');
+
+                    var device = application.getDevice();
+                    var createImageSpy = this.sandbox.spy(device, 'createImage');
+                    var el = widget.render(device);
+
+                    assert(createImageSpy.called);
+                    assertEquals(typeof device.createImage(), typeof el);
+                    assertEquals('id', el.id);
+                    var img = el.getElementsByTagName('img')[0];
+                    assertEquals('about:blank', img.src);
+                    assertEquals(size.width + 'px', el.style.width);
+                    assertEquals(size.height + 'px', el.style.height);
+                    assertClassName('image', el);
+                    assertClassName('testClass', el);
+                }
+        );
+    };
+
 
     this.ImageTest.prototype.testSetGetSource = function(queue) {
         expectAsserts(2);

--- a/static/script-tests/tests/widgets/image.js
+++ b/static/script-tests/tests/widgets/image.js
@@ -99,7 +99,7 @@
         );
     };
 
-     this.ImageTest.prototype.testRenderUnspecifiedMode = function(queue) {
+    this.ImageTest.prototype.testRenderUnspecifiedMode = function(queue) {
         expectAsserts(8);
 
         queuedApplicationInit(

--- a/static/script/widgets/image.js
+++ b/static/script/widgets/image.js
@@ -39,19 +39,20 @@ define(
          * @extends antie.widgets.Container
          * @param {String} [id] The unique ID of the widget. If excluded, a temporary internal ID will be used (but not included in any output).
          * @param {String} src The image source URL.
-         * @param {Size} size The size of the image.
+         * @param {Size} [size] The size of the image.
+         * @param {Number} [renderMode] What mode the image will be rendered in. Either Image.RENDER_MODE_IMG or Image.RENDER_MODE_CONTAINER.
          */
         var Image = Container.extend(/** @lends antie.widgets.Image.prototype */ {
             /**
              * @constructor
              * @ignore
              */
-            init: function(id, src, size) {
+            init: function(id, src, size, renderMode) {
                 this._super(id);
                 this._src = src;
                 this._size = size;
                 this._imageElement = null;
-                this._renderMode = Image.RENDER_MODE_CONTAINER;
+                this._renderMode = (renderMode === Image.RENDER_MODE_IMG) ? Image.RENDER_MODE_IMG : Image.RENDER_MODE_CONTAINER;
                 this.addClass('image');
             },
             /**
@@ -69,6 +70,7 @@ define(
                     device.prependChildElement(this.outputElement, this._imageElement);
                 } else {
                     this.outputElement = this._imageElement;
+                    device.setElementClasses(this.outputElement, this.getClasses());
                 }
 
                 return this.outputElement;


### PR DESCRIPTION
Fixes issue with CSS classes not being added when image render mode is IMG. 

Also takes render mode in constructor (defaults to CONTAINER if not specified).

Issue #360.
