### PR TITLE
widget redraw function added

### DIFF
--- a/static/script/widgets/widget.js
+++ b/static/script/widgets/widget.js
@@ -338,6 +338,20 @@ define(
                 } else {
                     throw new Error('Widget::moveTo called - the current widget has not yet been rendered.');
                 }
+            },
+
+            redraw: function () {
+                var output = this.outputElement;
+                var parent = output.parentElement;
+                var outputIndex = Array.prototype.indexOf.call(parent.children, output);
+                if (parent.children[outputIndex + 1]) {
+                    var nextElement = parent.children[outputIndex + 1];
+                    parent.removeChild(output);
+                    parent.insertBefore(output, nextElement);
+                } else {
+                    parent.removeChild(output);
+                    parent.appendChild(output);
+                }
             }
         });
     }


### PR DESCRIPTION
Fixes device bug around animation using css classes

start animation
add `display: none`
remove `display: none`

animation stops. In order to start the animation again we need to remove the element and put it back on. TAL does not refer to the element for it's events. Hence things like lists index are not affected