### PR TITLE
Make the broadcast visible after setChannelByName()

### DIFF
--- a/static/script-tests/tests/devices/broadcastsource/hbbtvsourcetest.js
+++ b/static/script-tests/tests/devices/broadcastsource/hbbtvsourcetest.js
@@ -893,11 +893,26 @@
         });
     };
 
-    this.hbbtvSource.prototype.testTuningToCurrentChannelByNameCausesShowOfCurrentChannel = function (queue) {
+    this.hbbtvSource.prototype.testTuningToCurrentChannelByNameCausesBroadcastToBeSetVisible = function (queue) {
         expectAsserts(4);
 
         var hbbtvPlugin = this.hbbtvPlugin;
         doChannelTuningTest(this, queue, 'BBC One', function () {
+            assert(hbbtvPlugin.bindToCurrentChannel.calledOnce);
+            assertEquals('1280px', hbbtvPlugin.style.width);
+            assertEquals('720px', hbbtvPlugin.style.height);
+            assertEquals('visible',hbbtvPlugin.style.visibility);
+        });
+    };
+
+    this.hbbtvSource.prototype.testTuningToNewChannelByNameCausesBroadcastToBeSetVisible = function (queue) {
+        expectAsserts(4);
+
+        var hbbtvPlugin = this.hbbtvPlugin;
+        doChannelTuningTest(this, queue, 'BBC Two', function () {
+            var evt = new CustomEvent('ChannelChangeSucceeded');
+            hbbtvPlugin.dispatchEvent(evt);
+
             assert(hbbtvPlugin.bindToCurrentChannel.calledOnce);
             assertEquals('1280px', hbbtvPlugin.style.width);
             assertEquals('720px', hbbtvPlugin.style.height);

--- a/static/script-tests/tests/devices/broadcastsource/hbbtvsourcetest.js
+++ b/static/script-tests/tests/devices/broadcastsource/hbbtvsourcetest.js
@@ -893,7 +893,7 @@
         });
     };
 
-    this.hbbtvSource.prototype.testTuningToCurrentChannelByNameCausesBroadcastToBeSetVisible = function (queue) {
+    this.hbbtvSource.prototype.testTuningToCurrentChannelByNameCausesChannelToBeShown = function (queue) {
         expectAsserts(4);
 
         var hbbtvPlugin = this.hbbtvPlugin;
@@ -906,14 +906,13 @@
     };
 
     this.hbbtvSource.prototype.testTuningToNewChannelByNameCausesBroadcastToBeSetVisible = function (queue) {
-        expectAsserts(4);
+        expectAsserts(3);
 
         var hbbtvPlugin = this.hbbtvPlugin;
         doChannelTuningTest(this, queue, 'BBC Two', function () {
             var evt = new CustomEvent('ChannelChangeSucceeded');
             hbbtvPlugin.dispatchEvent(evt);
 
-            assert(hbbtvPlugin.bindToCurrentChannel.calledOnce);
             assertEquals('1280px', hbbtvPlugin.style.width);
             assertEquals('720px', hbbtvPlugin.style.height);
             assertEquals('visible',hbbtvPlugin.style.visibility);

--- a/static/script/devices/broadcastsource/hbbtvsource.js
+++ b/static/script/devices/broadcastsource/hbbtvsource.js
@@ -209,6 +209,7 @@ define(
                 var successEventListener = function(/* channel */) {
                     self._broadcastVideoObject.removeEventListener('ChannelChangeSucceeded', successEventListener);
                     self._broadcastVideoObject.removeEventListener('ChannelChangeError', errorEventListener);
+                    self.showCurrentChannel();
                     onSuccess();
                 };
 

--- a/static/script/devices/broadcastsource/hbbtvsource.js
+++ b/static/script/devices/broadcastsource/hbbtvsource.js
@@ -92,9 +92,11 @@ define(
                 });
             },
             showCurrentChannel: function () {
-                // Check if exception is thrown by bindToCurrentChannel?
-                this._setBroadcastToFullScreen();
                 this._broadcastVideoObject.bindToCurrentChannel();
+                this._setBroadcastVisible();
+            },
+            _setBroadcastVisible: function () {
+                this._setBroadcastToFullScreen();
                 this._broadcastVideoObject.style.visibility = 'visible';
             },
             stopCurrentChannel: function () {
@@ -209,7 +211,7 @@ define(
                 var successEventListener = function(/* channel */) {
                     self._broadcastVideoObject.removeEventListener('ChannelChangeSucceeded', successEventListener);
                     self._broadcastVideoObject.removeEventListener('ChannelChangeError', errorEventListener);
-                    self.showCurrentChannel();
+                    self._setBroadcastVisible();
                     onSuccess();
                 };
 


### PR DESCRIPTION
Fix for HbbTVSource: currently the broadcast is only made visible if calling `setChannelByName()` when the tuner is already on the requested channel. This fix makes the broadcast visible after a successful retune too, making the behaviour consistent in both cases.