### PR TITLE
Ignore npm-debug.log files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 libpeerconnection.log
 *.iml
 node_modules
+**/*npm-debug.log
 .idea
 static/script-tests/jasmine/WebRunner.html
 .grunt


### PR DESCRIPTION
As part of investigating #380 I realised that any `npm-debug.log` files weren't being ignored, they probably should be.