### PR TITLE
Honor 'disableAutoResume' pause option in live seekable facade near start of seekable range.

### DIFF
--- a/static/script-tests/tests/devices/mediaplayer/live/seekable.js
+++ b/static/script-tests/tests/devices/mediaplayer/live/seekable.js
@@ -148,6 +148,49 @@
         }, config);
     };
 
+    this.LivePlayerSupportLevelSeekableTest.prototype.testSeekableLivePlayerPauseFakesImmediateAutoResumeNearStartOfSeekableRange = function (queue) {
+        queuedApplicationInit(queue, 'lib/mockapplication', ['antie/devices/mediaplayer/mediaplayer', 'antie/devices/device', 'antie/devices/mediaplayer/live/seekable'], function (application, MediaPlayer, Device) {
+            var device = new Device(antie.framework.deviceConfiguration);
+            var livePlayer = device.getLivePlayer();
+            var expectedRange = {
+                'start': 0,
+                'end': 30
+            };
+            this.sandbox.stub(livePlayer._mediaPlayer, 'getSeekableRange').returns(expectedRange);
+            this.sandbox.stub(livePlayer._mediaPlayer, 'getCurrentTime').returns(8);
+            var toPausedStub = this.sandbox.stub(livePlayer._mediaPlayer, '_toPaused');
+            var toPlayingStub = this.sandbox.stub(livePlayer._mediaPlayer, '_toPlaying');
+            var pauseStub = this.sandbox.stub(livePlayer._mediaPlayer, 'pause');
+
+            livePlayer.pause();
+            assert(pauseStub.notCalled);
+            assert(toPausedStub.calledOnce);
+            assert(toPlayingStub.calledOnce);
+            sinon.assert.callOrder(toPausedStub, toPlayingStub);
+        }, config);
+    };
+
+    this.LivePlayerSupportLevelSeekableTest.prototype.testSeekableLivePlayerPauseDoesNotFakeImmediateAutoResumeIfDisabledNearStartOfSeekableRange = function (queue) {
+        queuedApplicationInit(queue, 'lib/mockapplication', ['antie/devices/mediaplayer/mediaplayer', 'antie/devices/device', 'antie/devices/mediaplayer/live/seekable'], function (application, MediaPlayer, Device) {
+            var device = new Device(antie.framework.deviceConfiguration);
+            var livePlayer = device.getLivePlayer();
+            var expectedRange = {
+                'start': 0,
+                'end': 30
+            };
+            this.sandbox.stub(livePlayer._mediaPlayer, 'getSeekableRange').returns(expectedRange);
+            this.sandbox.stub(livePlayer._mediaPlayer, 'getCurrentTime').returns(8);
+            var toPausedStub = this.sandbox.stub(livePlayer._mediaPlayer, '_toPaused');
+            var toPlayingStub = this.sandbox.stub(livePlayer._mediaPlayer, '_toPlaying');
+            var pauseStub = this.sandbox.stub(livePlayer._mediaPlayer, 'pause');
+
+            livePlayer.pause({disableAutoResume: true});
+            assert(pauseStub.calledOnce);
+            assert(toPausedStub.notCalled);
+            assert(toPlayingStub.notCalled);
+        }, config);
+    };
+
     this.LivePlayerSupportLevelSeekableTest.prototype.testSeekableLivePlayerResumeCallsFunctionInMediaPlayer = testFunctionsInLivePlayerCallMediaPlayerFunctions('resume', 0);
 
     this.LivePlayerSupportLevelSeekableTest.prototype.testSeekableLivePlayerGetCurrentTimeCallsFunctionInMediaPlayer = testFunctionsInLivePlayerCallMediaPlayerFunctions('getCurrentTime', 0);

--- a/static/script/devices/mediaplayer/live/seekable.js
+++ b/static/script/devices/mediaplayer/live/seekable.js
@@ -78,19 +78,20 @@ define(
             },
 
             pause: function (opts) {
+                opts = opts || {};
                 var secondsUntilStartOfWindow = this._mediaPlayer.getCurrentTime() - this._mediaPlayer.getSeekableRange().start;
-                if (secondsUntilStartOfWindow > AUTO_RESUME_WINDOW_START_CUSHION_SECONDS) {
+
+                if (opts.disableAutoResume) {
                     this._mediaPlayer.pause();
-                    opts = opts || {};
-                    if(opts.disableAutoResume !== true){
-                        this._autoResumeAtStartOfRange();
-                    }
+                } else if (secondsUntilStartOfWindow <= AUTO_RESUME_WINDOW_START_CUSHION_SECONDS) {
+                  // IPLAYERTVV1-4166
+                  // We can't pause so close to the start of the sliding window, so do a quick state transition in and
+                  // out on 'pause' state to be consistent with the rest of TAL.
+                  this._mediaPlayer._toPaused();
+                  this._mediaPlayer._toPlaying();
                 } else {
-                    // IPLAYERTVV1-4166
-                    // We can't pause so close to the start of the sliding window, so do a quick state transition in and
-                    // out on 'pause' state to be consistent with the rest of TAL.
-                    this._mediaPlayer._toPaused();
-                    this._mediaPlayer._toPlaying();
+                  this._mediaPlayer.pause();
+                  this._autoResumeAtStartOfRange();
                 }
             },
             resume: function () {

--- a/static/script/devices/mediaplayer/live/seekable.js
+++ b/static/script/devices/mediaplayer/live/seekable.js
@@ -84,14 +84,14 @@ define(
                 if (opts.disableAutoResume) {
                     this._mediaPlayer.pause();
                 } else if (secondsUntilStartOfWindow <= AUTO_RESUME_WINDOW_START_CUSHION_SECONDS) {
-                  // IPLAYERTVV1-4166
-                  // We can't pause so close to the start of the sliding window, so do a quick state transition in and
-                  // out on 'pause' state to be consistent with the rest of TAL.
-                  this._mediaPlayer._toPaused();
-                  this._mediaPlayer._toPlaying();
+                    // IPLAYERTVV1-4166
+                    // We can't pause so close to the start of the sliding window, so do a quick state transition in and
+                    // out on 'pause' state to be consistent with the rest of TAL.
+                    this._mediaPlayer._toPaused();
+                    this._mediaPlayer._toPlaying();
                 } else {
-                  this._mediaPlayer.pause();
-                  this._autoResumeAtStartOfRange();
+                    this._mediaPlayer.pause();
+                    this._autoResumeAtStartOfRange();
                 }
             },
             resume: function () {


### PR DESCRIPTION
Currently we always fake an auto resume if pause is called near the start of the seekable range, but we should not do this if pause is called with the 'disableAutoResume' option.