### PR TITLE
Fix #380: update jsdoc to not use exec

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -1,147 +1,137 @@
 module.exports = function(grunt) {
-    'use strict';
+  'use strict';
 
-    grunt.initConfig({
-        pkg: grunt.file.readJSON('package.json'),
-        eslint: {
-            src: [
-                'static/script/**/*.js',
-                'static/script-tests/**/*.js'
-            ],
-            options: {
-                quiet: true
-            }
-        },
-        jasmine: {
-            src: 'static/script/**/*.js',
-            options: {
-                specs: ['static/script-tests/tests/**/*.js'],
-                vendor: [
-                    'static/script-tests/lib/sinon.js',
-                    'static/script-tests/lib/ondevicetestconfigvalidate.js',
-                    'static/script-tests/lib/require.js',
-                    'static/script-tests/jasmine/jstestdriver-adapter.js',
-                    'static/script-tests/lib/mockapplication.js',
-                    'static/script-tests/lib/phantompolyfills.js',
-                    'static/script-tests/mocks/mockelement.js',
-                    'static/script-tests/tests/devices/mediaplayer/commontests.js',
-                    'static/script-tests/tests/devices/mediaplayer/html5commontests.js',
-                    'static/script-tests/tests/devices/mediaplayer/cehtmlcommontests.js'
-                ],
-                styles: [
-                    'static/script-tests/lib/carousels.css',
-                    'static/script-tests/lib/css3transitions.css'
-                ],
-                template: 'static/script-tests/jasmine/SpecRunner.html',
-                outfile: 'static/script-tests/jasmine/WebRunner.html',
-                keepRunner: true,
-                display: 'full',
-                templateOptions: {
-                    scriptRoot: '../..',
-                    frameworkVersion: '2.1.0'
-                }
-            }
-        },
-        watch: {
-            eslint: {
-                files: ['static/script/**/*.js'],
-                tasks: ['eslint']
-            }
-        },
-        complexity: {
-            generic: {
-                src: ['static/script/**/*.js'],
-                exclude: ['static/script/targets/core.js'],
-                expand: true,
-                options: {
-                    breakOnErrors: false,
-                    jsLintXML: 'report.xml', // create XML JSLint-like report
-                    checkstyleXML: 'checkstyle.xml', // create checkstyle report
-                    errorsOnly: false, // show only maintainability errors
-                    cyclomatic: [3, 7, 12], // or optionally a single value, like 3
-                    halstead: [8, 13, 20], // [difficulty, volume, effort] or optionally a single value, like 8
-                    maintainability: 100,
-                    hideComplexFunctions: false, // only display maintainability
-                    broadcast: false // broadcast data over event-bus
-                }
-            }
-        },
-        replace: {
-            'jsdoc-tidy': {
-                src: ['jsdoc/**/*.html'],
-                overwrite: true,
-                replacements: [{
-                    from: '../symbols/',
-                    to: ''
-                }, {
-                    from: '</body>',
-                    to: grunt.file.read('jsdoc/footer.txt').trim() + '</body>'
-                }]
-            }
-        },
-        bump: {
-            options: {
-                files: ['package.json', 'bower.json'],
-                updateConfigs: [],
-                commit: true,
-                commitMessage: 'Release v%VERSION%' + (grunt.option('m') ? ' - ' + grunt.option('m') : ''),
-                commitFiles: ['package.json', 'bower.json'],
-                createTag: true,
-                tagName: '%VERSION%',
-                tagMessage: 'Version %VERSION%' + (grunt.option('m') ? ' - ' + grunt.option('m') : ''),
-                push: true,
-                pushTo: 'origin',
-                gitDescribeOptions: '--tags --always --abbrev=1 --dirty=-d',
-                globalReplace: false,
-                prereleaseName: false,
-                regExp: false
-            }
-        },
-        shell: {
-            coverage: {
-                command: 'cd static/script-tests/jasmine; pwd; ./coverage.sh -p;'
-            }
+  grunt.initConfig({
+    pkg: grunt.file.readJSON('package.json'),
+    eslint: {
+      src: [
+        'static/script/**/*.js',
+        'static/script-tests/**/*.js'
+      ],
+      options: {
+        quiet: true
+      }
+    },
+    jasmine: {
+      src: 'static/script/**/*.js',
+      options: {
+        specs: ['static/script-tests/tests/**/*.js'],
+        vendor: [
+          'static/script-tests/lib/sinon.js',
+          'static/script-tests/lib/ondevicetestconfigvalidate.js',
+          'static/script-tests/lib/require.js',
+          'static/script-tests/jasmine/jstestdriver-adapter.js',
+          'static/script-tests/lib/mockapplication.js',
+          'static/script-tests/lib/phantompolyfills.js',
+          'static/script-tests/mocks/mockelement.js',
+          'static/script-tests/tests/devices/mediaplayer/commontests.js',
+          'static/script-tests/tests/devices/mediaplayer/html5commontests.js',
+          'static/script-tests/tests/devices/mediaplayer/cehtmlcommontests.js'
+        ],
+        styles: [
+          'static/script-tests/lib/carousels.css',
+          'static/script-tests/lib/css3transitions.css'
+        ],
+        template: 'static/script-tests/jasmine/SpecRunner.html',
+        outfile: 'static/script-tests/jasmine/WebRunner.html',
+        keepRunner: true,
+        display: 'full',
+        templateOptions: {
+          scriptRoot: '../..',
+          frameworkVersion: '2.1.0'
         }
-    });
-
-    grunt.registerTask('generate-jsdoc', 'Generate JsDoc for TAL', function() {
-        var path = require('path');
-        var execSync = require('exec-sync');
-
-        if (grunt.file.exists('jsdoc/symbols')) {
-            grunt.file.delete('jsdoc/symbols');
+      }
+    },
+    watch: {
+      eslint: {
+        files: ['static/script/**/*.js'],
+        tasks: ['eslint']
+      }
+    },
+    complexity: {
+      generic: {
+        src: ['static/script/**/*.js'],
+        exclude: ['static/script/targets/core.js'],
+        expand: true,
+        options: {
+          breakOnErrors: false,
+          jsLintXML: 'report.xml', // create XML JSLint-like report
+          checkstyleXML: 'checkstyle.xml', // create checkstyle report
+          errorsOnly: false, // show only maintainability errors
+          cyclomatic: [3, 7, 12], // or optionally a single value, like 3
+          halstead: [8, 13, 20], // [difficulty, volume, effort] or optionally a single value, like 8
+          maintainability: 100,
+          hideComplexFunctions: false, // only display maintainability
+          broadcast: false // broadcast data over event-bus
         }
-        grunt.file.recurse('static/script', function(absPath, rootDir, subDir, fileName) {
-            subDir = subDir || '';
-            grunt.file.copy(absPath, path.join('antie', 'static', 'script', subDir, fileName));
-        });
+      }
+    },
+    replace: {
+      'jsdoc-tidy': {
+        src: ['jsdoc/**/*.html'],
+        overwrite: true,
+        replacements: [{
+          from: '../symbols/',
+          to: ''
+        }, {
+          from: '</body>',
+          to: grunt.file.read('jsdoc/footer.txt').trim() + '</body>'
+        }]
+      }
+    },
+    bump: {
+      options: {
+        files: ['package.json', 'bower.json'],
+        updateConfigs: [],
+        commit: true,
+        commitMessage: 'Release v%VERSION%' + (grunt.option('m') ? ' - ' + grunt.option('m') : ''),
+        commitFiles: ['package.json', 'bower.json'],
+        createTag: true,
+        tagName: '%VERSION%',
+        tagMessage: 'Version %VERSION%' + (grunt.option('m') ? ' - ' + grunt.option('m') : ''),
+        push: true,
+        pushTo: 'origin',
+        gitDescribeOptions: '--tags --always --abbrev=1 --dirty=-d',
+        globalReplace: false,
+        prereleaseName: false,
+        regExp: false
+      }
+    },
+    shell: {
+      coverage: {
+        command: 'cd static/script-tests/jasmine; pwd; ./coverage.sh -p;'
+      }
+    },
+    jsdoc : {
+      dist : {
+        src: ['static/script/*/**.js'],
+        options: {
+          destination: 'jsdoc'
+        }
+      }
+    }
+  });
 
-        execSync('node_modules/jsdoc-toolkit/app/run.js -r=10 -t=node_modules/jsdoc-toolkit/templates/jsdoc -d=jsdoc antie/static/script');
-        grunt.file.delete('antie');
-    });
+  grunt.loadNpmTasks('grunt-contrib-watch');
+  grunt.loadNpmTasks('grunt-contrib-jasmine');
+  grunt.loadNpmTasks('grunt-complexity');
+  grunt.loadNpmTasks('grunt-text-replace');
+  grunt.loadNpmTasks('grunt-bump');
+  grunt.loadNpmTasks('gruntify-eslint');
+  grunt.loadNpmTasks('grunt-jsdoc');
 
-    grunt.loadNpmTasks('grunt-contrib-watch');
-    grunt.loadNpmTasks('grunt-contrib-jasmine');
-    grunt.loadNpmTasks('grunt-complexity');
-    grunt.loadNpmTasks('grunt-text-replace');
-    grunt.loadNpmTasks('grunt-shell');
-    grunt.loadNpmTasks('grunt-bump');
-    grunt.loadNpmTasks('gruntify-eslint');
+  grunt.registerTask('test', ['jasmine', 'eslint']);
+  grunt.registerTask('lint', ['eslint']);
 
+  grunt.registerTask('full', ['eslint', 'jasmine']);
+  grunt.registerTask('default', 'full');
+  grunt.registerTask('coverage', 'Produce a coverage report of the main source files', ['jasmine:src:build', 'shell:coverage']);
+  grunt.registerTask('spec', ['jasmine:src:build', 'openspec']);
 
-    grunt.registerTask('test', ['jasmine', 'eslint']);
-    grunt.registerTask('lint', ['eslint']);
-
-    grunt.registerTask('jsdoc', ['generate-jsdoc', 'replace:jsdoc-tidy']);
-    grunt.registerTask('full', ['eslint', 'jasmine']);
-    grunt.registerTask('default', 'full');
-    grunt.registerTask('coverage', 'Produce a coverage report of the main source files', ['jasmine:src:build', 'shell:coverage']);
-    grunt.registerTask('spec', ['jasmine:src:build', 'openspec']);
-
-    grunt.registerTask('openspec', 'Open the generated Jasmine spec file', function() {
-        var childProcess = require('child_process');
-        var outfile = grunt.config('jasmine.options.outfile');
-        grunt.log.writeln('Opening ' + outfile + '...');
-        childProcess.exec('open ' + outfile);
-    });
+  grunt.registerTask('openspec', 'Open the generated Jasmine spec file', function() {
+    var childProcess = require('child_process');
+    var outfile = grunt.config('jasmine.options.outfile');
+    grunt.log.writeln('Opening ' + outfile + '...');
+    childProcess.exec('open ' + outfile);
+  });
 };

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -1,137 +1,137 @@
 module.exports = function(grunt) {
-  'use strict';
+    'use strict';
 
-  grunt.initConfig({
-    pkg: grunt.file.readJSON('package.json'),
-    eslint: {
-      src: [
-        'static/script/**/*.js',
-        'static/script-tests/**/*.js'
-      ],
-      options: {
-        quiet: true
-      }
-    },
-    jasmine: {
-      src: 'static/script/**/*.js',
-      options: {
-        specs: ['static/script-tests/tests/**/*.js'],
-        vendor: [
-          'static/script-tests/lib/sinon.js',
-          'static/script-tests/lib/ondevicetestconfigvalidate.js',
-          'static/script-tests/lib/require.js',
-          'static/script-tests/jasmine/jstestdriver-adapter.js',
-          'static/script-tests/lib/mockapplication.js',
-          'static/script-tests/lib/phantompolyfills.js',
-          'static/script-tests/mocks/mockelement.js',
-          'static/script-tests/tests/devices/mediaplayer/commontests.js',
-          'static/script-tests/tests/devices/mediaplayer/html5commontests.js',
-          'static/script-tests/tests/devices/mediaplayer/cehtmlcommontests.js'
-        ],
-        styles: [
-          'static/script-tests/lib/carousels.css',
-          'static/script-tests/lib/css3transitions.css'
-        ],
-        template: 'static/script-tests/jasmine/SpecRunner.html',
-        outfile: 'static/script-tests/jasmine/WebRunner.html',
-        keepRunner: true,
-        display: 'full',
-        templateOptions: {
-          scriptRoot: '../..',
-          frameworkVersion: '2.1.0'
+    grunt.initConfig({
+        pkg: grunt.file.readJSON('package.json'),
+        eslint: {
+            src: [
+                'static/script/**/*.js',
+                'static/script-tests/**/*.js'
+            ],
+            options: {
+                quiet: true
+            }
+        },
+        jasmine: {
+            src: 'static/script/**/*.js',
+            options: {
+                specs: ['static/script-tests/tests/**/*.js'],
+                vendor: [
+                    'static/script-tests/lib/sinon.js',
+                    'static/script-tests/lib/ondevicetestconfigvalidate.js',
+                    'static/script-tests/lib/require.js',
+                    'static/script-tests/jasmine/jstestdriver-adapter.js',
+                    'static/script-tests/lib/mockapplication.js',
+                    'static/script-tests/lib/phantompolyfills.js',
+                    'static/script-tests/mocks/mockelement.js',
+                    'static/script-tests/tests/devices/mediaplayer/commontests.js',
+                    'static/script-tests/tests/devices/mediaplayer/html5commontests.js',
+                    'static/script-tests/tests/devices/mediaplayer/cehtmlcommontests.js'
+                ],
+                styles: [
+                    'static/script-tests/lib/carousels.css',
+                    'static/script-tests/lib/css3transitions.css'
+                ],
+                template: 'static/script-tests/jasmine/SpecRunner.html',
+                outfile: 'static/script-tests/jasmine/WebRunner.html',
+                keepRunner: true,
+                display: 'full',
+                templateOptions: {
+                    scriptRoot: '../..',
+                    frameworkVersion: '2.1.0'
+                }
+            }
+        },
+        watch: {
+            eslint: {
+                files: ['static/script/**/*.js'],
+                tasks: ['eslint']
+            }
+        },
+        complexity: {
+            generic: {
+                src: ['static/script/**/*.js'],
+                exclude: ['static/script/targets/core.js'],
+                expand: true,
+                options: {
+                    breakOnErrors: false,
+                    jsLintXML: 'report.xml', // create XML JSLint-like report
+                    checkstyleXML: 'checkstyle.xml', // create checkstyle report
+                    errorsOnly: false, // show only maintainability errors
+                    cyclomatic: [3, 7, 12], // or optionally a single value, like 3
+                    halstead: [8, 13, 20], // [difficulty, volume, effort] or optionally a single value, like 8
+                    maintainability: 100,
+                    hideComplexFunctions: false, // only display maintainability
+                    broadcast: false // broadcast data over event-bus
+                }
+            }
+        },
+        replace: {
+            'jsdoc-tidy': {
+                src: ['jsdoc/**/*.html'],
+                overwrite: true,
+                replacements: [{
+                    from: '../symbols/',
+                    to: ''
+                }, {
+                    from: '</body>',
+                    to: grunt.file.read('jsdoc/footer.txt').trim() + '</body>'
+                }]
+            }
+        },
+        bump: {
+            options: {
+                files: ['package.json', 'bower.json'],
+                updateConfigs: [],
+                commit: true,
+                commitMessage: 'Release v%VERSION%' + (grunt.option('m') ? ' - ' + grunt.option('m') : ''),
+                commitFiles: ['package.json', 'bower.json'],
+                createTag: true,
+                tagName: '%VERSION%',
+                tagMessage: 'Version %VERSION%' + (grunt.option('m') ? ' - ' + grunt.option('m') : ''),
+                push: true,
+                pushTo: 'origin',
+                gitDescribeOptions: '--tags --always --abbrev=1 --dirty=-d',
+                globalReplace: false,
+                prereleaseName: false,
+                regExp: false
+            }
+        },
+        shell: {
+            coverage: {
+                command: 'cd static/script-tests/jasmine; pwd; ./coverage.sh -p;'
+            }
+        },
+        jsdoc: {
+            dist: {
+                src: ['static/script/*/**.js'],
+                options: {
+                    destination: 'jsdoc'
+                }
+            }
         }
-      }
-    },
-    watch: {
-      eslint: {
-        files: ['static/script/**/*.js'],
-        tasks: ['eslint']
-      }
-    },
-    complexity: {
-      generic: {
-        src: ['static/script/**/*.js'],
-        exclude: ['static/script/targets/core.js'],
-        expand: true,
-        options: {
-          breakOnErrors: false,
-          jsLintXML: 'report.xml', // create XML JSLint-like report
-          checkstyleXML: 'checkstyle.xml', // create checkstyle report
-          errorsOnly: false, // show only maintainability errors
-          cyclomatic: [3, 7, 12], // or optionally a single value, like 3
-          halstead: [8, 13, 20], // [difficulty, volume, effort] or optionally a single value, like 8
-          maintainability: 100,
-          hideComplexFunctions: false, // only display maintainability
-          broadcast: false // broadcast data over event-bus
-        }
-      }
-    },
-    replace: {
-      'jsdoc-tidy': {
-        src: ['jsdoc/**/*.html'],
-        overwrite: true,
-        replacements: [{
-          from: '../symbols/',
-          to: ''
-        }, {
-          from: '</body>',
-          to: grunt.file.read('jsdoc/footer.txt').trim() + '</body>'
-        }]
-      }
-    },
-    bump: {
-      options: {
-        files: ['package.json', 'bower.json'],
-        updateConfigs: [],
-        commit: true,
-        commitMessage: 'Release v%VERSION%' + (grunt.option('m') ? ' - ' + grunt.option('m') : ''),
-        commitFiles: ['package.json', 'bower.json'],
-        createTag: true,
-        tagName: '%VERSION%',
-        tagMessage: 'Version %VERSION%' + (grunt.option('m') ? ' - ' + grunt.option('m') : ''),
-        push: true,
-        pushTo: 'origin',
-        gitDescribeOptions: '--tags --always --abbrev=1 --dirty=-d',
-        globalReplace: false,
-        prereleaseName: false,
-        regExp: false
-      }
-    },
-    shell: {
-      coverage: {
-        command: 'cd static/script-tests/jasmine; pwd; ./coverage.sh -p;'
-      }
-    },
-    jsdoc : {
-      dist : {
-        src: ['static/script/*/**.js'],
-        options: {
-          destination: 'jsdoc'
-        }
-      }
-    }
-  });
+    });
 
-  grunt.loadNpmTasks('grunt-contrib-watch');
-  grunt.loadNpmTasks('grunt-contrib-jasmine');
-  grunt.loadNpmTasks('grunt-complexity');
-  grunt.loadNpmTasks('grunt-text-replace');
-  grunt.loadNpmTasks('grunt-bump');
-  grunt.loadNpmTasks('gruntify-eslint');
-  grunt.loadNpmTasks('grunt-jsdoc');
+    grunt.loadNpmTasks('grunt-contrib-watch');
+    grunt.loadNpmTasks('grunt-contrib-jasmine');
+    grunt.loadNpmTasks('grunt-complexity');
+    grunt.loadNpmTasks('grunt-text-replace');
+    grunt.loadNpmTasks('grunt-bump');
+    grunt.loadNpmTasks('gruntify-eslint');
+    grunt.loadNpmTasks('grunt-jsdoc');
 
-  grunt.registerTask('test', ['jasmine', 'eslint']);
-  grunt.registerTask('lint', ['eslint']);
+    grunt.registerTask('test', ['jasmine', 'eslint']);
+    grunt.registerTask('lint', ['eslint']);
 
-  grunt.registerTask('full', ['eslint', 'jasmine']);
-  grunt.registerTask('default', 'full');
-  grunt.registerTask('coverage', 'Produce a coverage report of the main source files', ['jasmine:src:build', 'shell:coverage']);
-  grunt.registerTask('spec', ['jasmine:src:build', 'openspec']);
+    grunt.registerTask('full', ['eslint', 'jasmine']);
+    grunt.registerTask('default', 'full');
+    grunt.registerTask('coverage', 'Produce a coverage report of the main source files', ['jasmine:src:build', 'shell:coverage']);
+    grunt.registerTask('spec', ['jasmine:src:build', 'openspec']);
 
-  grunt.registerTask('openspec', 'Open the generated Jasmine spec file', function() {
-    var childProcess = require('child_process');
-    var outfile = grunt.config('jasmine.options.outfile');
-    grunt.log.writeln('Opening ' + outfile + '...');
-    childProcess.exec('open ' + outfile);
-  });
+    grunt.registerTask('openspec', 'Open the generated Jasmine spec file', function() {
+        var childProcess = require('child_process');
+        var outfile = grunt.config('jasmine.options.outfile');
+        grunt.log.writeln('Opening ' + outfile + '...');
+        childProcess.exec('open ' + outfile);
+    });
 };

--- a/package.json
+++ b/package.json
@@ -16,17 +16,16 @@
   "devDependencies": {
     "eslint-plugin-jasmine": "^1.6.0",
     "eslint-plugin-requirejs": "^0.6.0",
-    "exec-sync": "latest",
     "grunt": "^0.4.5",
     "grunt-bump": "^0.6.0",
     "grunt-cli": "~0.1.6",
     "grunt-complexity": "^0.2.0",
     "grunt-contrib-jasmine": "~0.5.2",
     "grunt-contrib-watch": "~0.6.1",
+    "grunt-jsdoc": "^2.1.0",
     "grunt-shell": "^1.1.1",
     "grunt-text-replace": "^0.4.0",
-    "gruntify-eslint": "^1.3.0",
-    "jsdoc-toolkit": "latest"
+    "gruntify-eslint": "^1.3.0"
   },
   "dependencies": {
     "es5-shim": "^4.5.9",


### PR DESCRIPTION
Removes dependency on node-gyp, which was erroring on install previously.