### PR TITLE
Fix sorting of layout sizes

### DIFF
--- a/static/script/application.js
+++ b/static/script/application.js
@@ -130,7 +130,7 @@ define('antie/application',
 
                 // sort the layouts by largest first
                 _layouts.sort(function (a, b) {
-                    var ad = (a.width * a.width) + (a.height * b.height),
+                    var ad = (a.width * a.width) + (a.height * a.height),
                         bd = (b.width * b.width) + (b.height * b.height);
                     if (ad === bd) {
                         return 0;


### PR DESCRIPTION
As determined in issues #222 & #365 the `getBestFitLayout` method has a weird calculation where the `b` argument was used in the size calculation for `a`

Created this PR just to lay it to rest.