### PR TITLE
Check for an expected exception by name, not message

### DIFF
--- a/static/script-tests/tests/devices/device.js
+++ b/static/script-tests/tests/devices/device.js
@@ -95,7 +95,7 @@ require(
 
                 expect(callbacks.onSuccess).not.toHaveBeenCalled();
                 expect(callbacks.onError).toHaveBeenCalledWith(jasmine.any(Object));
-                expect(callbacks.onError.calls[0].args[0].message).toMatch(/'undefined' is not an object/);
+                expect(callbacks.onError.calls[0].args[0].name).toBe('TypeError');
             });
 
             it('chokes on default exit()', function() {


### PR DESCRIPTION
The message for this TypeError in Chrome is "Cannot read property 'base' of undefined", but the test expects PhantomJS's "'undefined' is not an object". Fix this by checking for the exception name instead, which is always TypeError regardless of your test runner environment.